### PR TITLE
This is a further worked on notebook Synthetic mock community analysi…

### DIFF
--- a/scripts/Notebooks/Synthetic_mock_community_analysis.ipynb
+++ b/scripts/Notebooks/Synthetic_mock_community_analysis.ipynb
@@ -1,0 +1,3441 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Notebook to analyzse the efficiency of minimap mapping against a mock community"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Starting points from Tavish  \n",
+    "reference_dataframe at '/media/MassStorage/tmp/TE/honours/analysis/Stats/reference_dataframe.csv'  \n",
+    "custom_database at '/media/MassStorage/tmp/TE/honours/database/custom_database_labelled.fasta'  \n",
+    "taxonomy_file at '/media/MassStorage/tmp/TE/honours/analysis/Stats/taxonomy_file.csv'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### workflow\n",
+    "\n",
+    "* Two databases\n",
+    "* subsample 15000 reads per each mock community species. Save those out.\n",
+    "* map reads against both databases with minimap safe out data in paf format.\n",
+    "* get best hit per species (see what this means while looking at the data).\n",
+    "* add the full taxonomy to each best match using the taxonomy file.\n",
+    "* summarize data at different taxonomic ranks for each species.\n",
+    "* pull this all together somehow (summary across all the samples? focus on species of interest e.g. deleted from analyis?)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### requirment\n",
+    "\n",
+    "* Bbmap (conda install bbmap https://anaconda.org/bioconda/bbmap)  \n",
+    "* minimap2 (conda install minimap2 https://anaconda.org/bioconda/minimap2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### fixes on the command line\n",
+    "\n",
+    "* fixed the taxonomy file to fit with the quiime format\n",
+    "\n",
+    "cat /media/MassStorage/tmp/TE/honours/analysis/Stats/taxonomy_file.csv | sed 's/,/\\t/' > /media/MassStorage/tmp/TE/honours/analysis/Stats/taxonomy_file_v2.csv"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### fix the taxonomy_file_v2.csv more to reflect Qiime style\n",
+    "\n",
+    "* This requires to make the species name genus_species and not _species.... hope this makes sense"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "old_taxonomy_file_fn = '/media/MassStorage/tmp/TE/honours/analysis/Stats/taxonomy_file_v2.csv'\n",
+    "new_taxonomy_file_fn = '/media/MassStorage/tmp/TE/honours/analysis/Stats/taxonomy_file_v3.csv'\n",
+    "with open(new_taxonomy_file_fn, 'w') as out_fh:\n",
+    "    with open(old_taxonomy_file_fn, 'r') as in_fh:\n",
+    "        for line in in_fh:\n",
+    "            line = line.rstrip()\n",
+    "            #print(line)\n",
+    "            first_half = line.split('s__')[0]\n",
+    "            second_half = line.split('s__')[1]\n",
+    "            pattern = re.compile(r'g__\\w+;')\n",
+    "            genus = re.findall(pattern, first_half)[0].replace('g__','').replace(';','')\n",
+    "            new_line = F\"{first_half}s__{genus}_{second_half}\"\n",
+    "            print(new_line,file=out_fh)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "20171103_FAH15473/barcode01\tk__Fungi;p__Basidiomycota;c__Pucciniomycetes;o__Pucciniales;f__Pucciniaceae;g__Puccinia;s__striiformis-tritici\r\n",
+      "20171103_FAH15473/barcode02\tk__Fungi;p__Ascomycota;c__Dothideomycetes;o__Capnodiales;f__Mycosphaerellaceae;g__Zymoseptoria;s__tritici\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!head -2 {old_taxonomy_file_fn}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "20171103_FAH15473/barcode01\tk__Fungi;p__Basidiomycota;c__Pucciniomycetes;o__Pucciniales;f__Pucciniaceae;g__Puccinia;s__Puccinia_striiformis-tritici\r\n",
+      "20171103_FAH15473/barcode02\tk__Fungi;p__Ascomycota;c__Dothideomycetes;o__Capnodiales;f__Mycosphaerellaceae;g__Zymoseptoria;s__Zymoseptoria_tritici\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!head -2 {new_taxonomy_file_fn}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from Bio import SeqIO\n",
+    "import os\n",
+    "import random\n",
+    "import subprocess\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Initial data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reference_dataframe_fn = os.path.abspath('/media/MassStorage/tmp/TE/honours/analysis/Stats/reference_dataframe.csv')\n",
+    "max_custom_database_fn = os.path.abspath('/media/MassStorage/tmp/TE/honours/database/custom_database_labelled.fasta')\n",
+    "taxonomy_file_fn = os.path.abspath('/media/MassStorage/tmp/TE/honours/analysis/Stats/taxonomy_file_v3.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#threads to use\n",
+    "threads = 6"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "INPUT_BASEDIR = os.path.abspath('/media/MassStorage/tmp/TE/honours')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "OUT_DIR = os.path.abspath('../../analysis/Mapping_mock_gsref')\n",
+    "if not os.path.exists(OUT_DIR):\n",
+    "    os.mkdir(OUT_DIR)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### list of species in the max database\n",
+    "max_species = ['Puccinia_striiformis_tritici',\n",
+    " 'Zymoseptoria_tritici',\n",
+    " 'Pyrenophora_tritici-repentis',\n",
+    " 'Fusarium_oxysporum',\n",
+    " 'Tuber_brumale',\n",
+    " 'Cortinarius_globuliformis',\n",
+    " 'Aspergillus_niger',\n",
+    " 'Clavispora_lusitaniae',\n",
+    " 'Cryptococcus_neoformans',\n",
+    " 'Penicillium_chrysogenum',\n",
+    " 'Rhodotorula_mucilaginosa',\n",
+    " 'Scedosporium_boydii',\n",
+    " 'Blastobotrys_proliferans',\n",
+    " 'Candida_zeylanoides',\n",
+    " 'Galactomyces_geotrichum',\n",
+    " 'Kodamaea_ohmeri',\n",
+    " 'Meyerozyma_guillermondii',\n",
+    " 'Wickerhamomyces_anomalus',\n",
+    " 'Yamadazyma_mexicana',\n",
+    " 'Yamadazyma_scolyti',\n",
+    " 'Yarrowia_lipolytica',\n",
+    " 'Zygoascus_hellenicus',\n",
+    " 'Aspergillus_flavus',\n",
+    " 'Cryptococcus_zero',\n",
+    " 'Aspergillus_sp.',\n",
+    " 'CCL067',\n",
+    " 'Diaporthe_sp.',\n",
+    " 'Tapesia_yallundae_CCL031',\n",
+    " 'Tapesia_yallundae_CCL029',\n",
+    " 'Dothiorella_vidmadera',\n",
+    " 'Quambalaria_cyanescens',\n",
+    " 'Entoleuca_sp.',\n",
+    " 'CCL060',\n",
+    " 'CCL068',\n",
+    " 'Saccharomyces_cerevisiae',\n",
+    " 'Cladophialophora_sp.',\n",
+    " 'Candida_albicans',\n",
+    " 'Candida_metapsilosis',\n",
+    " 'Candida_orthopsilosis',\n",
+    " 'Candida_parapsilosis',\n",
+    " 'Geotrichum_candidum',\n",
+    " 'Kluyveromyces_lactis',\n",
+    " 'Kluyveromyces_marxianus',\n",
+    " 'Pichia_kudriavzevii',\n",
+    " 'Pichia_membranifaciens']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "###Removed from second test databes\n",
+    "species_delete = ['Candida_orthopsilosis',\n",
+    "                 'Candida_metapsilosis',\n",
+    "                 'Aspergillus_niger']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "###species to be searched against both databases\n",
+    "mock_community = ['Penicillium_chrysogenum',\n",
+    " 'Aspergillus_flavus',\n",
+    " 'Aspergillus_niger',\n",
+    " 'Pichia_kudriavzevii',\n",
+    " 'Pichia_membranifaciens',\n",
+    " 'Candida_albicans',\n",
+    " 'Candida_parapsilosis',\n",
+    " 'Candida_orthopsilosis',\n",
+    " 'Candida_metapsilosis']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fixed_old_names = ['Kluyveromyces_lactis',\n",
+    "                   'Candida_zeylanoides',\n",
+    "                   'Cladophialophora_sp.',\n",
+    "                   'Diaporthe_sp.',\n",
+    "                   'CCL060',\n",
+    "                   'CCL068',\n",
+    "                   'CCL067',\n",
+    "                   'Aspergillus_sp.',\n",
+    "                   'Entoleuca_sp.',\n",
+    "                   'Tapesia_yallundae_CCL029',\n",
+    "                   'Tapesia_yallundae_CCL031',\n",
+    "                   'Cryptococcus_neoformans']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fixed_new_names = ['candida_unidentified',\n",
+    "                   'debaryomyces_unidentified',\n",
+    "                   'cladophialophora_unidentified',\n",
+    "                   'diaporthe_unidentified',\n",
+    "                   'asteroma_ccl060',\n",
+    "                   'asteroma_ccl068',\n",
+    "                   'diaporthe_ccl067',\n",
+    "                   'aspergillus_unidentified',\n",
+    "                   'entoleuca_unidentified',\n",
+    "                   'oculimacula_yallundae-ccl029',\n",
+    "                   'oculimacula_yallundae-ccl031',\n",
+    "                   'kluyveromyces_unidentified']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "old_to_new_names = dict(zip(fixed_old_names, fixed_new_names))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Kluyveromyces_lactis': 'candida_unidentified',\n",
+       " 'Candida_zeylanoides': 'debaryomyces_unidentified',\n",
+       " 'Cladophialophora_sp.': 'cladophialophora_unidentified',\n",
+       " 'Diaporthe_sp.': 'diaporthe_unidentified',\n",
+       " 'CCL060': 'asteroma_ccl060',\n",
+       " 'CCL068': 'asteroma_ccl068',\n",
+       " 'CCL067': 'diaporthe_ccl067',\n",
+       " 'Aspergillus_sp.': 'aspergillus_unidentified',\n",
+       " 'Entoleuca_sp.': 'entoleuca_unidentified',\n",
+       " 'Tapesia_yallundae_CCL029': 'oculimacula_yallundae-ccl029',\n",
+       " 'Tapesia_yallundae_CCL031': 'oculimacula_yallundae-ccl031',\n",
+       " 'Cryptococcus_neoformans': 'kluyveromyces_unidentified'}"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "old_to_new_names"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Fix databases and names"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ref_df = pd.read_csv(reference_dataframe_fn)\n",
+    "ref_df['name_species'] = ref_df['genus'] +\"_\"+ ref_df['species']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['puccinia_striiformis-tritici',\n",
+       " 'zymoseptoria_tritici',\n",
+       " 'pyrenophora_tritici-repentis',\n",
+       " 'fusarium_oxysporum',\n",
+       " 'tuber_brumale',\n",
+       " 'cortinarius_globuliformis',\n",
+       " 'aspergillus_niger',\n",
+       " 'clavispora_lusitaniae',\n",
+       " 'kluyveromyces_unidentified',\n",
+       " 'penicillium_chrysogenum',\n",
+       " 'rhodotorula_mucilaginosa',\n",
+       " 'scedosporium_boydii',\n",
+       " 'blastobotrys_proliferans',\n",
+       " 'debaryomyces_unidentified',\n",
+       " 'galactomyces_geotrichum',\n",
+       " 'kodamaea_ohmeri',\n",
+       " 'meyerozyma_guillermondii',\n",
+       " 'wickerhamomyces_anomalus',\n",
+       " 'yamadazyma_mexicana',\n",
+       " 'yamadazyma_scolyti',\n",
+       " 'yarrowia_lipolytica',\n",
+       " 'zygoascus_hellenicus',\n",
+       " 'aspergillus_flavus',\n",
+       " 'cryptococcus_zero',\n",
+       " 'aspergillus_unidentified',\n",
+       " 'diaporthe_ccl067',\n",
+       " 'diaporthe_unidentified',\n",
+       " 'oculimacula_yallundae-ccl031',\n",
+       " 'oculimacula_yallundae-ccl029',\n",
+       " 'dothiorella_vidmadera',\n",
+       " 'quambalaria_cyanescens',\n",
+       " 'entoleuca_unidentified',\n",
+       " 'asteroma_ccl060',\n",
+       " 'asteroma_ccl068',\n",
+       " 'saccharomyces_cerevisiae',\n",
+       " 'cladophialophora_unidentified',\n",
+       " 'candida_albicans',\n",
+       " 'candida_metapsilosis',\n",
+       " 'candida_orthopsilosis',\n",
+       " 'candida_parapsilosis',\n",
+       " 'candida_unidentified',\n",
+       " 'kluyveromyces_marxianus',\n",
+       " 'pichia_kudriavzevii',\n",
+       " 'pichia_membranifaciens']"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ref_df.name_species.tolist()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_db_fn = os.path.join(OUT_DIR, 'gsref.db.fasta')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_db_list = []\n",
+    "old_db_list = []\n",
+    "for seq in SeqIO.parse(max_custom_database_fn, 'fasta'):\n",
+    "    old_db_list.append(seq.id)\n",
+    "    if seq.id in old_to_new_names.keys():\n",
+    "        #print(seq.id)\n",
+    "        seq.id = seq.name = seq.description = old_to_new_names[seq.id]\n",
+    "        new_db_list.append(seq)\n",
+    "    elif seq.id.lower() in ref_df.name_species.tolist():\n",
+    "        #print(seq.id)\n",
+    "        seq.id = seq.name = seq.description = seq.id.lower()\n",
+    "        new_db_list.append(seq)\n",
+    "    else:\n",
+    "        print(seq.id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "please check!\n"
+     ]
+    }
+   ],
+   "source": [
+    "if len(new_db_list) == len(old_db_list) -2:\n",
+    "    SeqIO.write(new_db_list, new_db_fn, 'fasta')\n",
+    "else:\n",
+    "    print(\"please check!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sub_db_fn = os.path.join(OUT_DIR, 'gsref.subdb.fasta')\n",
+    "sub_db_list = []\n",
+    "for seq in new_db_list:\n",
+    "    if seq.id not in [x.lower() for x in species_delete]:\n",
+    "        sub_db_list.append(seq)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if len(sub_db_list) + len(species_delete) == len(new_db_list):\n",
+    "    SeqIO.write(sub_db_list, sub_db_fn, 'fasta' )\n",
+    "else:\n",
+    "    print(\"please check!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['puccinia_striiformis-tritici',\n",
+       " 'zymoseptoria_tritici',\n",
+       " 'pyrenophora_tritici-repentis',\n",
+       " 'fusarium_oxysporum',\n",
+       " 'tuber_brumale',\n",
+       " 'cortinarius_globuliformis',\n",
+       " 'clavispora_lusitaniae',\n",
+       " 'kluyveromyces_unidentified',\n",
+       " 'penicillium_chrysogenum',\n",
+       " 'rhodotorula_mucilaginosa',\n",
+       " 'scedosporium_boydii',\n",
+       " 'blastobotrys_proliferans',\n",
+       " 'debaryomyces_unidentified',\n",
+       " 'galactomyces_geotrichum',\n",
+       " 'kodamaea_ohmeri',\n",
+       " 'meyerozyma_guillermondii',\n",
+       " 'wickerhamomyces_anomalus',\n",
+       " 'yamadazyma_mexicana',\n",
+       " 'yamadazyma_scolyti',\n",
+       " 'yarrowia_lipolytica',\n",
+       " 'zygoascus_hellenicus',\n",
+       " 'aspergillus_flavus',\n",
+       " 'cryptococcus_zero',\n",
+       " 'aspergillus_unidentified',\n",
+       " 'diaporthe_ccl067',\n",
+       " 'diaporthe_unidentified',\n",
+       " 'oculimacula_yallundae-ccl031',\n",
+       " 'oculimacula_yallundae-ccl029',\n",
+       " 'dothiorella_vidmadera',\n",
+       " 'quambalaria_cyanescens',\n",
+       " 'entoleuca_unidentified',\n",
+       " 'asteroma_ccl060',\n",
+       " 'asteroma_ccl068',\n",
+       " 'saccharomyces_cerevisiae',\n",
+       " 'cladophialophora_unidentified',\n",
+       " 'candida_albicans',\n",
+       " 'candida_parapsilosis',\n",
+       " 'candida_unidentified',\n",
+       " 'kluyveromyces_marxianus',\n",
+       " 'pichia_kudriavzevii',\n",
+       " 'pichia_membranifaciens']"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "[x.id for x in sub_db_list]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mock_community = [x.lower() for x in mock_community]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['penicillium_chrysogenum',\n",
+       " 'aspergillus_flavus',\n",
+       " 'aspergillus_niger',\n",
+       " 'pichia_kudriavzevii',\n",
+       " 'pichia_membranifaciens',\n",
+       " 'candida_albicans',\n",
+       " 'candida_parapsilosis',\n",
+       " 'candida_orthopsilosis',\n",
+       " 'candida_metapsilosis']"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mock_community"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Subsample reads"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def subsamplereads(in_fn, out_fn, n_reads):\n",
+    "    command = F'reformat.sh samplereadstarget={n_reads} in={in_fn} out={out_fn}'\n",
+    "    out = subprocess.getstatusoutput(command)\n",
+    "    if out[0] == 0:\n",
+    "        print(F\":)Completed {command}\\n\")\n",
+    "    else:\n",
+    "        print(F\":(check one {command}!!\\n\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_reads = 15000"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MC_READ_DIR = os.path.join(OUT_DIR, 'MC_READS')\n",
+    "if not os.path.exists(MC_READ_DIR):\n",
+    "    os.mkdir(MC_READ_DIR)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['Unnamed: 0', 'species', 'genus', 'family', 'order', 'class', 'phylum',\n",
+       "       'kingdom', '# raw reads', '# reads after homology filtering',\n",
+       "       '# reads after length filtering', '# for use', 'path to raw reads',\n",
+       "       'path to homology filtering', 'path to length filtering',\n",
+       "       'path for use', 'name_species'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ref_df.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'penicillium_chrysogenum': '/media/MassStorage/tmp/TE/honours/analysis/Length_Filtered/20171103_FAH15473/barcode10/length_restricted_for_use.fasta',\n",
+       " 'aspergillus_flavus': '/media/MassStorage/tmp/TE/honours/analysis/Length_Filtered/20171207_FAH18654/barcode12/length_restricted_for_use.fasta',\n",
+       " 'aspergillus_niger': '/media/MassStorage/tmp/TE/honours/analysis/Length_Filtered/20171103_FAH15473/barcode07/length_restricted_for_use.fasta',\n",
+       " 'pichia_kudriavzevii': '/media/MassStorage/tmp/TE/honours/analysis/Length_Filtered/20180108_FAH18647/barcode11/length_restricted_for_use.fasta',\n",
+       " 'pichia_membranifaciens': '/media/MassStorage/tmp/TE/honours/analysis/Length_Filtered/20180108_FAH18647/barcode12/length_restricted_for_use.fasta',\n",
+       " 'candida_albicans': '/media/MassStorage/tmp/TE/honours/analysis/Length_Filtered/20180108_FAH18647/barcode03/length_restricted_for_use.fasta',\n",
+       " 'candida_parapsilosis': '/media/MassStorage/tmp/TE/honours/analysis/Length_Filtered/20180108_FAH18647/barcode06/length_restricted_for_use.fasta',\n",
+       " 'candida_orthopsilosis': '/media/MassStorage/tmp/TE/honours/analysis/Length_Filtered/20180108_FAH18647/barcode05/length_restricted_for_use.fasta',\n",
+       " 'candida_metapsilosis': '/media/MassStorage/tmp/TE/honours/analysis/Length_Filtered/20180108_FAH18647/barcode04/length_restricted_for_use.fasta'}"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fn_subsampling = {}\n",
+    "for x in mock_community:\n",
+    "    fn_subsampling[x] = (ref_df[(ref_df['species'] == x.split('_')[1]) & (ref_df['genus'] == x.split('_')[0])]['path for use'].tolist()[0])\n",
+    "    fn_subsampling[x] = os.path.join(INPUT_BASEDIR, fn_subsampling[x])\n",
+    "fn_subsampling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ":(check one reformat.sh samplereadstarget=15000 in=/media/MassStorage/tmp/TE/honours/analysis/Length_Filtered/20171103_FAH15473/barcode10/length_restricted_for_use.fasta out=/media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/MC_READS/penicillium_chrysogenum.15000.fasta!!\n",
+      "\n",
+      ":(check one reformat.sh samplereadstarget=15000 in=/media/MassStorage/tmp/TE/honours/analysis/Length_Filtered/20171207_FAH18654/barcode12/length_restricted_for_use.fasta out=/media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/MC_READS/aspergillus_flavus.15000.fasta!!\n",
+      "\n",
+      ":(check one reformat.sh samplereadstarget=15000 in=/media/MassStorage/tmp/TE/honours/analysis/Length_Filtered/20171103_FAH15473/barcode07/length_restricted_for_use.fasta out=/media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/MC_READS/aspergillus_niger.15000.fasta!!\n",
+      "\n",
+      ":(check one reformat.sh samplereadstarget=15000 in=/media/MassStorage/tmp/TE/honours/analysis/Length_Filtered/20180108_FAH18647/barcode11/length_restricted_for_use.fasta out=/media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/MC_READS/pichia_kudriavzevii.15000.fasta!!\n",
+      "\n",
+      ":(check one reformat.sh samplereadstarget=15000 in=/media/MassStorage/tmp/TE/honours/analysis/Length_Filtered/20180108_FAH18647/barcode12/length_restricted_for_use.fasta out=/media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/MC_READS/pichia_membranifaciens.15000.fasta!!\n",
+      "\n",
+      ":(check one reformat.sh samplereadstarget=15000 in=/media/MassStorage/tmp/TE/honours/analysis/Length_Filtered/20180108_FAH18647/barcode03/length_restricted_for_use.fasta out=/media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/MC_READS/candida_albicans.15000.fasta!!\n",
+      "\n",
+      ":(check one reformat.sh samplereadstarget=15000 in=/media/MassStorage/tmp/TE/honours/analysis/Length_Filtered/20180108_FAH18647/barcode06/length_restricted_for_use.fasta out=/media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/MC_READS/candida_parapsilosis.15000.fasta!!\n",
+      "\n",
+      ":(check one reformat.sh samplereadstarget=15000 in=/media/MassStorage/tmp/TE/honours/analysis/Length_Filtered/20180108_FAH18647/barcode05/length_restricted_for_use.fasta out=/media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/MC_READS/candida_orthopsilosis.15000.fasta!!\n",
+      "\n",
+      ":(check one reformat.sh samplereadstarget=15000 in=/media/MassStorage/tmp/TE/honours/analysis/Length_Filtered/20180108_FAH18647/barcode04/length_restricted_for_use.fasta out=/media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/MC_READS/candida_metapsilosis.15000.fasta!!\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "sub_reads_fn = {}\n",
+    "for key, value in fn_subsampling.items():\n",
+    "    species = key\n",
+    "    in_fn = value\n",
+    "    out_fn = os.path.join(MC_READ_DIR, F'{species}.{n_reads}.fasta')\n",
+    "    subsamplereads(in_fn, out_fn, n_reads)\n",
+    "    sub_reads_fn[species] = out_fn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Map with minimap against both databases"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def minimapmapping(fasta_fn, ref_fn, out_fn, threads):\n",
+    "    command = F\"minimap2 -x map-ont -t {threads} {ref_fn} {fasta_fn} -o {out_fn}\"\n",
+    "    out = subprocess.getstatusoutput(command)\n",
+    "    if out[0] == 0:\n",
+    "        print(F\":)Completed {command}\\n\")\n",
+    "    else:\n",
+    "        print(F\":(check one {command}!!\\n\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'/media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref.subdb.fasta': '/media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref_subdb',\n",
+       " '/media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref.db.fasta': '/media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref_db'}"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dbases_fn = {}\n",
+    "for x in [sub_db_fn, new_db_fn]:\n",
+    "    dbases_fn[x] = os.path.join(OUT_DIR, os.path.basename(x).replace('.fasta', '').replace('.','_'))\n",
+    "    if not os.path.exists(dbases_fn[x]):\n",
+    "        os.mkdir(dbases_fn[x])\n",
+    "dbases_fn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ":)Completed minimap2 -x map-ont -t 6 /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref.subdb.fasta /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/MC_READS/penicillium_chrysogenum.15000.fasta -o /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref_subdb/gsref.subdb.penicillium_chrysogenum.minimap2.paf\n",
+      "\n",
+      ":)Completed minimap2 -x map-ont -t 6 /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref.subdb.fasta /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/MC_READS/aspergillus_flavus.15000.fasta -o /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref_subdb/gsref.subdb.aspergillus_flavus.minimap2.paf\n",
+      "\n",
+      ":)Completed minimap2 -x map-ont -t 6 /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref.subdb.fasta /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/MC_READS/aspergillus_niger.15000.fasta -o /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref_subdb/gsref.subdb.aspergillus_niger.minimap2.paf\n",
+      "\n",
+      ":)Completed minimap2 -x map-ont -t 6 /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref.subdb.fasta /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/MC_READS/pichia_kudriavzevii.15000.fasta -o /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref_subdb/gsref.subdb.pichia_kudriavzevii.minimap2.paf\n",
+      "\n",
+      ":)Completed minimap2 -x map-ont -t 6 /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref.subdb.fasta /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/MC_READS/pichia_membranifaciens.15000.fasta -o /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref_subdb/gsref.subdb.pichia_membranifaciens.minimap2.paf\n",
+      "\n",
+      ":)Completed minimap2 -x map-ont -t 6 /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref.subdb.fasta /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/MC_READS/candida_albicans.15000.fasta -o /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref_subdb/gsref.subdb.candida_albicans.minimap2.paf\n",
+      "\n",
+      ":)Completed minimap2 -x map-ont -t 6 /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref.subdb.fasta /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/MC_READS/candida_parapsilosis.15000.fasta -o /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref_subdb/gsref.subdb.candida_parapsilosis.minimap2.paf\n",
+      "\n",
+      ":)Completed minimap2 -x map-ont -t 6 /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref.subdb.fasta /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/MC_READS/candida_orthopsilosis.15000.fasta -o /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref_subdb/gsref.subdb.candida_orthopsilosis.minimap2.paf\n",
+      "\n",
+      ":)Completed minimap2 -x map-ont -t 6 /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref.subdb.fasta /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/MC_READS/candida_metapsilosis.15000.fasta -o /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref_subdb/gsref.subdb.candida_metapsilosis.minimap2.paf\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "db_fn = sub_db_fn\n",
+    "sub_db_mapping_fn = {}\n",
+    "for species, fasta_fn in sub_reads_fn.items():\n",
+    "    tmp_out = dbases_fn[db_fn]\n",
+    "    db_name = os.path.basename(db_fn).replace('.fasta', '')\n",
+    "    out_fn = os.path.join(tmp_out, F\"{db_name}.{species}.minimap2.paf\")\n",
+    "    sub_db_mapping_fn[species] = out_fn\n",
+    "    minimapmapping(fasta_fn, db_fn, out_fn, threads)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ":)Completed minimap2 -x map-ont -t 6 /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref.db.fasta /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/MC_READS/penicillium_chrysogenum.15000.fasta -o /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref_db/gsref.db.penicillium_chrysogenum.minimap2.paf\n",
+      "\n",
+      ":)Completed minimap2 -x map-ont -t 6 /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref.db.fasta /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/MC_READS/aspergillus_flavus.15000.fasta -o /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref_db/gsref.db.aspergillus_flavus.minimap2.paf\n",
+      "\n",
+      ":)Completed minimap2 -x map-ont -t 6 /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref.db.fasta /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/MC_READS/aspergillus_niger.15000.fasta -o /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref_db/gsref.db.aspergillus_niger.minimap2.paf\n",
+      "\n",
+      ":)Completed minimap2 -x map-ont -t 6 /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref.db.fasta /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/MC_READS/pichia_kudriavzevii.15000.fasta -o /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref_db/gsref.db.pichia_kudriavzevii.minimap2.paf\n",
+      "\n",
+      ":)Completed minimap2 -x map-ont -t 6 /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref.db.fasta /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/MC_READS/pichia_membranifaciens.15000.fasta -o /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref_db/gsref.db.pichia_membranifaciens.minimap2.paf\n",
+      "\n",
+      ":)Completed minimap2 -x map-ont -t 6 /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref.db.fasta /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/MC_READS/candida_albicans.15000.fasta -o /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref_db/gsref.db.candida_albicans.minimap2.paf\n",
+      "\n",
+      ":)Completed minimap2 -x map-ont -t 6 /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref.db.fasta /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/MC_READS/candida_parapsilosis.15000.fasta -o /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref_db/gsref.db.candida_parapsilosis.minimap2.paf\n",
+      "\n",
+      ":)Completed minimap2 -x map-ont -t 6 /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref.db.fasta /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/MC_READS/candida_orthopsilosis.15000.fasta -o /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref_db/gsref.db.candida_orthopsilosis.minimap2.paf\n",
+      "\n",
+      ":)Completed minimap2 -x map-ont -t 6 /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref.db.fasta /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/MC_READS/candida_metapsilosis.15000.fasta -o /media/WorkingStorage/ben.working/students/tavish/analysis/Mapping_mock_gsref/gsref_db/gsref.db.candida_metapsilosis.minimap2.paf\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "db_fn = new_db_fn\n",
+    "new_db_mapping_fn = {}\n",
+    "for species, fasta_fn in sub_reads_fn.items():\n",
+    "    tmp_out = dbases_fn[db_fn]\n",
+    "    db_name = os.path.basename(db_fn).replace('.fasta', '')\n",
+    "    out_fn = os.path.join(tmp_out, F\"{db_name}.{species}.minimap2.paf\")\n",
+    "    new_db_mapping_fn[species] = out_fn\n",
+    "    minimapmapping(fasta_fn, db_fn, out_fn, threads)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Look at mapping results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def mapping_results(fn, species):\n",
+    "    min_header = ['qseqid', 'qlen', 'qstart', 'qstop', 'strand', 'tname', 'tlen', 'tstart', 'tend', 'nmatch', 'alen', 'mquality']\n",
+    "    tmp_df = pd.read_csv(fn, sep='\\t', header = None, usecols=[x for x in range(0,12)], names=min_header)\n",
+    "    sub_df = tmp_df[tmp_df['mquality'] == tmp_df.groupby('qseqid')['mquality'].transform(max)].reset_index(drop=True)\n",
+    "    sub_df = sub_df[sub_df['nmatch'] == sub_df.groupby('qseqid')['nmatch'].transform(max)].reset_index(drop=True)\n",
+    "    hit_series = pd.Series(sub_df.groupby('tname')['mquality'].count().tolist()/sub_df.groupby('tname')['mquality'].count().sum(),\n",
+    "                      sub_df.groupby('tname')['mquality'].count().index)\n",
+    "    hit_series.sort_values(ascending=False, inplace=True)\n",
+    "    print(sub_df.qseqid.unique().shape == tmp_df.qseqid.unique().shape)\n",
+    "    print('##########\\n')\n",
+    "    print(F\"This was the query species: {species}\\n\")\n",
+    "    print(F\"These are the results:\")\n",
+    "    print(hit_series,'\\n')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n",
+      "##########\n",
+      "\n",
+      "This was the query species: penicillium_chrysogenum\n",
+      "\n",
+      "These are the results:\n",
+      "tname\n",
+      "penicillium_chrysogenum          0.992277\n",
+      "aspergillus_niger                0.001798\n",
+      "aspergillus_flavus               0.001398\n",
+      "aspergillus_unidentified         0.000932\n",
+      "tuber_brumale                    0.000666\n",
+      "kluyveromyces_marxianus          0.000466\n",
+      "zymoseptoria_tritici             0.000466\n",
+      "pyrenophora_tritici-repentis     0.000333\n",
+      "kluyveromyces_unidentified       0.000266\n",
+      "puccinia_striiformis-tritici     0.000200\n",
+      "cortinarius_globuliformis        0.000133\n",
+      "asteroma_ccl060                  0.000133\n",
+      "clavispora_lusitaniae            0.000133\n",
+      "scedosporium_boydii              0.000067\n",
+      "rhodotorula_mucilaginosa         0.000067\n",
+      "asteroma_ccl068                  0.000067\n",
+      "cladophialophora_unidentified    0.000067\n",
+      "pichia_membranifaciens           0.000067\n",
+      "oculimacula_yallundae-ccl031     0.000067\n",
+      "diaporthe_unidentified           0.000067\n",
+      "fusarium_oxysporum               0.000067\n",
+      "kodamaea_ohmeri                  0.000067\n",
+      "meyerozyma_guillermondii         0.000067\n",
+      "oculimacula_yallundae-ccl029     0.000067\n",
+      "cryptococcus_zero                0.000067\n",
+      "dtype: float64 \n",
+      "\n",
+      "True\n",
+      "##########\n",
+      "\n",
+      "This was the query species: aspergillus_flavus\n",
+      "\n",
+      "These are the results:\n",
+      "tname\n",
+      "aspergillus_flavus              0.995603\n",
+      "aspergillus_niger               0.001599\n",
+      "aspergillus_unidentified        0.001466\n",
+      "penicillium_chrysogenum         0.000333\n",
+      "cryptococcus_zero               0.000133\n",
+      "entoleuca_unidentified          0.000133\n",
+      "fusarium_oxysporum              0.000067\n",
+      "asteroma_ccl068                 0.000067\n",
+      "blastobotrys_proliferans        0.000067\n",
+      "zymoseptoria_tritici            0.000067\n",
+      "yarrowia_lipolytica             0.000067\n",
+      "oculimacula_yallundae-ccl031    0.000067\n",
+      "rhodotorula_mucilaginosa        0.000067\n",
+      "scedosporium_boydii             0.000067\n",
+      "yamadazyma_mexicana             0.000067\n",
+      "yamadazyma_scolyti              0.000067\n",
+      "kodamaea_ohmeri                 0.000067\n",
+      "dtype: float64 \n",
+      "\n",
+      "True\n",
+      "##########\n",
+      "\n",
+      "This was the query species: aspergillus_niger\n",
+      "\n",
+      "These are the results:\n",
+      "tname\n",
+      "aspergillus_niger                0.842123\n",
+      "aspergillus_unidentified         0.146855\n",
+      "aspergillus_flavus               0.006072\n",
+      "penicillium_chrysogenum          0.001056\n",
+      "entoleuca_unidentified           0.000660\n",
+      "rhodotorula_mucilaginosa         0.000396\n",
+      "yamadazyma_mexicana              0.000330\n",
+      "tuber_brumale                    0.000264\n",
+      "yamadazyma_scolyti               0.000264\n",
+      "meyerozyma_guillermondii         0.000132\n",
+      "cladophialophora_unidentified    0.000132\n",
+      "clavispora_lusitaniae            0.000132\n",
+      "debaryomyces_unidentified        0.000132\n",
+      "zymoseptoria_tritici             0.000132\n",
+      "oculimacula_yallundae-ccl029     0.000132\n",
+      "puccinia_striiformis-tritici     0.000132\n",
+      "quambalaria_cyanescens           0.000066\n",
+      "wickerhamomyces_anomalus         0.000066\n",
+      "scedosporium_boydii              0.000066\n",
+      "blastobotrys_proliferans         0.000066\n",
+      "candida_metapsilosis             0.000066\n",
+      "candida_unidentified             0.000066\n",
+      "saccharomyces_cerevisiae         0.000066\n",
+      "cortinarius_globuliformis        0.000066\n",
+      "kluyveromyces_marxianus          0.000066\n",
+      "cryptococcus_zero                0.000066\n",
+      "pyrenophora_tritici-repentis     0.000066\n",
+      "diaporthe_ccl067                 0.000066\n",
+      "diaporthe_unidentified           0.000066\n",
+      "dothiorella_vidmadera            0.000066\n",
+      "oculimacula_yallundae-ccl031     0.000066\n",
+      "fusarium_oxysporum               0.000066\n",
+      "dtype: float64 \n",
+      "\n",
+      "True\n",
+      "##########\n",
+      "\n",
+      "This was the query species: pichia_kudriavzevii\n",
+      "\n",
+      "These are the results:\n",
+      "tname\n",
+      "pichia_kudriavzevii              0.995871\n",
+      "pichia_membranifaciens           0.001998\n",
+      "candida_orthopsilosis            0.000400\n",
+      "candida_unidentified             0.000266\n",
+      "candida_metapsilosis             0.000200\n",
+      "candida_albicans                 0.000133\n",
+      "tuber_brumale                    0.000133\n",
+      "cladophialophora_unidentified    0.000133\n",
+      "clavispora_lusitaniae            0.000133\n",
+      "galactomyces_geotrichum          0.000133\n",
+      "cortinarius_globuliformis        0.000067\n",
+      "yamadazyma_scolyti               0.000067\n",
+      "debaryomyces_unidentified        0.000067\n",
+      "yamadazyma_mexicana              0.000067\n",
+      "kodamaea_ohmeri                  0.000067\n",
+      "meyerozyma_guillermondii         0.000067\n",
+      "oculimacula_yallundae-ccl031     0.000067\n",
+      "pyrenophora_tritici-repentis     0.000067\n",
+      "kluyveromyces_unidentified       0.000067\n",
+      "dtype: float64 \n",
+      "\n",
+      "True\n",
+      "##########\n",
+      "\n",
+      "This was the query species: pichia_membranifaciens\n",
+      "\n",
+      "These are the results:\n",
+      "tname\n",
+      "pichia_membranifaciens           0.995134\n",
+      "pichia_kudriavzevii              0.001800\n",
+      "candida_metapsilosis             0.000333\n",
+      "candida_parapsilosis             0.000333\n",
+      "yarrowia_lipolytica              0.000267\n",
+      "kluyveromyces_unidentified       0.000267\n",
+      "wickerhamomyces_anomalus         0.000267\n",
+      "candida_orthopsilosis            0.000200\n",
+      "kodamaea_ohmeri                  0.000200\n",
+      "meyerozyma_guillermondii         0.000133\n",
+      "kluyveromyces_marxianus          0.000133\n",
+      "debaryomyces_unidentified        0.000133\n",
+      "clavispora_lusitaniae            0.000133\n",
+      "saccharomyces_cerevisiae         0.000133\n",
+      "candida_albicans                 0.000133\n",
+      "yamadazyma_scolyti               0.000067\n",
+      "oculimacula_yallundae-ccl029     0.000067\n",
+      "galactomyces_geotrichum          0.000067\n",
+      "cladophialophora_unidentified    0.000067\n",
+      "quambalaria_cyanescens           0.000067\n",
+      "rhodotorula_mucilaginosa         0.000067\n",
+      "dtype: float64 \n",
+      "\n",
+      "True\n",
+      "##########\n",
+      "\n",
+      "This was the query species: candida_albicans\n",
+      "\n",
+      "These are the results:\n",
+      "tname\n",
+      "candida_albicans                0.498132\n",
+      "candida_unidentified            0.302718\n",
+      "candida_orthopsilosis           0.105372\n",
+      "candida_metapsilosis            0.049981\n",
+      "candida_parapsilosis            0.029821\n",
+      "galactomyces_geotrichum         0.001481\n",
+      "meyerozyma_guillermondii        0.001417\n",
+      "debaryomyces_unidentified       0.001288\n",
+      "kodamaea_ohmeri                 0.000966\n",
+      "yamadazyma_scolyti              0.000902\n",
+      "entoleuca_unidentified          0.000902\n",
+      "oculimacula_yallundae-ccl029    0.000773\n",
+      "yamadazyma_mexicana             0.000773\n",
+      "kluyveromyces_unidentified      0.000644\n",
+      "kluyveromyces_marxianus         0.000580\n",
+      "tuber_brumale                   0.000580\n",
+      "clavispora_lusitaniae           0.000515\n",
+      "saccharomyces_cerevisiae        0.000515\n",
+      "wickerhamomyces_anomalus        0.000322\n",
+      "pyrenophora_tritici-repentis    0.000258\n",
+      "quambalaria_cyanescens          0.000258\n",
+      "fusarium_oxysporum              0.000193\n",
+      "rhodotorula_mucilaginosa        0.000193\n",
+      "pichia_kudriavzevii             0.000129\n",
+      "dothiorella_vidmadera           0.000129\n",
+      "diaporthe_unidentified          0.000129\n",
+      "diaporthe_ccl067                0.000129\n",
+      "blastobotrys_proliferans        0.000129\n",
+      "zygoascus_hellenicus            0.000129\n",
+      "pichia_membranifaciens          0.000129\n",
+      "asteroma_ccl068                 0.000064\n",
+      "zymoseptoria_tritici            0.000064\n",
+      "cortinarius_globuliformis       0.000064\n",
+      "cryptococcus_zero               0.000064\n",
+      "penicillium_chrysogenum         0.000064\n",
+      "scedosporium_boydii             0.000064\n",
+      "yarrowia_lipolytica             0.000064\n",
+      "aspergillus_unidentified        0.000064\n",
+      "dtype: float64 \n",
+      "\n",
+      "True\n",
+      "##########\n",
+      "\n",
+      "This was the query species: candida_parapsilosis\n",
+      "\n",
+      "These are the results:\n",
+      "tname\n",
+      "candida_parapsilosis             0.902654\n",
+      "candida_orthopsilosis            0.047333\n",
+      "candida_metapsilosis             0.040207\n",
+      "candida_unidentified             0.001308\n",
+      "oculimacula_yallundae-ccl029     0.001046\n",
+      "meyerozyma_guillermondii         0.000785\n",
+      "tuber_brumale                    0.000654\n",
+      "candida_albicans                 0.000588\n",
+      "kodamaea_ohmeri                  0.000392\n",
+      "entoleuca_unidentified           0.000392\n",
+      "pichia_membranifaciens           0.000392\n",
+      "yamadazyma_scolyti               0.000327\n",
+      "wickerhamomyces_anomalus         0.000327\n",
+      "debaryomyces_unidentified        0.000327\n",
+      "kluyveromyces_marxianus          0.000262\n",
+      "zygoascus_hellenicus             0.000262\n",
+      "clavispora_lusitaniae            0.000262\n",
+      "yamadazyma_mexicana              0.000262\n",
+      "yarrowia_lipolytica              0.000262\n",
+      "galactomyces_geotrichum          0.000196\n",
+      "kluyveromyces_unidentified       0.000196\n",
+      "pichia_kudriavzevii              0.000196\n",
+      "rhodotorula_mucilaginosa         0.000196\n",
+      "saccharomyces_cerevisiae         0.000196\n",
+      "dothiorella_vidmadera            0.000131\n",
+      "cortinarius_globuliformis        0.000131\n",
+      "blastobotrys_proliferans         0.000131\n",
+      "fusarium_oxysporum               0.000065\n",
+      "diaporthe_unidentified           0.000065\n",
+      "cryptococcus_zero                0.000065\n",
+      "oculimacula_yallundae-ccl031     0.000065\n",
+      "cladophialophora_unidentified    0.000065\n",
+      "pyrenophora_tritici-repentis     0.000065\n",
+      "quambalaria_cyanescens           0.000065\n",
+      "asteroma_ccl060                  0.000065\n",
+      "aspergillus_unidentified         0.000065\n",
+      "dtype: float64 \n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n",
+      "##########\n",
+      "\n",
+      "This was the query species: candida_orthopsilosis\n",
+      "\n",
+      "These are the results:\n",
+      "tname\n",
+      "candida_orthopsilosis            0.734469\n",
+      "candida_metapsilosis             0.204357\n",
+      "candida_parapsilosis             0.041606\n",
+      "meyerozyma_guillermondii         0.010132\n",
+      "candida_unidentified             0.001330\n",
+      "candida_albicans                 0.000887\n",
+      "tuber_brumale                    0.000633\n",
+      "galactomyces_geotrichum          0.000570\n",
+      "kodamaea_ohmeri                  0.000507\n",
+      "yamadazyma_scolyti               0.000507\n",
+      "saccharomyces_cerevisiae         0.000507\n",
+      "debaryomyces_unidentified        0.000443\n",
+      "clavispora_lusitaniae            0.000380\n",
+      "entoleuca_unidentified           0.000380\n",
+      "oculimacula_yallundae-ccl029     0.000380\n",
+      "yarrowia_lipolytica              0.000317\n",
+      "zygoascus_hellenicus             0.000317\n",
+      "cladophialophora_unidentified    0.000253\n",
+      "yamadazyma_mexicana              0.000253\n",
+      "blastobotrys_proliferans         0.000190\n",
+      "kluyveromyces_marxianus          0.000190\n",
+      "puccinia_striiformis-tritici     0.000127\n",
+      "pyrenophora_tritici-repentis     0.000127\n",
+      "kluyveromyces_unidentified       0.000127\n",
+      "pichia_membranifaciens           0.000127\n",
+      "oculimacula_yallundae-ccl031     0.000127\n",
+      "diaporthe_unidentified           0.000063\n",
+      "cryptococcus_zero                0.000063\n",
+      "dothiorella_vidmadera            0.000063\n",
+      "quambalaria_cyanescens           0.000063\n",
+      "rhodotorula_mucilaginosa         0.000063\n",
+      "scedosporium_boydii              0.000063\n",
+      "wickerhamomyces_anomalus         0.000063\n",
+      "fusarium_oxysporum               0.000063\n",
+      "asteroma_ccl068                  0.000063\n",
+      "aspergillus_unidentified         0.000063\n",
+      "aspergillus_niger                0.000063\n",
+      "aspergillus_flavus               0.000063\n",
+      "dtype: float64 \n",
+      "\n",
+      "True\n",
+      "##########\n",
+      "\n",
+      "This was the query species: candida_metapsilosis\n",
+      "\n",
+      "These are the results:\n",
+      "tname\n",
+      "candida_metapsilosis             0.519748\n",
+      "candida_orthopsilosis            0.413375\n",
+      "candida_parapsilosis             0.054574\n",
+      "kodamaea_ohmeri                  0.002965\n",
+      "candida_unidentified             0.001325\n",
+      "oculimacula_yallundae-ccl029     0.000946\n",
+      "meyerozyma_guillermondii         0.000883\n",
+      "candida_albicans                 0.000631\n",
+      "saccharomyces_cerevisiae         0.000505\n",
+      "clavispora_lusitaniae            0.000442\n",
+      "tuber_brumale                    0.000442\n",
+      "debaryomyces_unidentified        0.000379\n",
+      "blastobotrys_proliferans         0.000315\n",
+      "kluyveromyces_marxianus          0.000315\n",
+      "kluyveromyces_unidentified       0.000252\n",
+      "entoleuca_unidentified           0.000252\n",
+      "galactomyces_geotrichum          0.000252\n",
+      "quambalaria_cyanescens           0.000189\n",
+      "asteroma_ccl068                  0.000189\n",
+      "yarrowia_lipolytica              0.000189\n",
+      "diaporthe_unidentified           0.000189\n",
+      "cortinarius_globuliformis        0.000126\n",
+      "asteroma_ccl060                  0.000126\n",
+      "cladophialophora_unidentified    0.000126\n",
+      "aspergillus_flavus               0.000126\n",
+      "pichia_kudriavzevii              0.000126\n",
+      "pyrenophora_tritici-repentis     0.000126\n",
+      "scedosporium_boydii              0.000126\n",
+      "wickerhamomyces_anomalus         0.000126\n",
+      "yamadazyma_mexicana              0.000126\n",
+      "yamadazyma_scolyti               0.000126\n",
+      "cryptococcus_zero                0.000063\n",
+      "dothiorella_vidmadera            0.000063\n",
+      "zygoascus_hellenicus             0.000063\n",
+      "rhodotorula_mucilaginosa         0.000063\n",
+      "aspergillus_unidentified         0.000063\n",
+      "zymoseptoria_tritici             0.000063\n",
+      "dtype: float64 \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "###this is running the reads against the full database\n",
+    "for species, hit_fn in new_db_mapping_fn.items():\n",
+    "    mapping_results(hit_fn, species)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "True\n",
+      "##########\n",
+      "\n",
+      "This was the query species: penicillium_chrysogenum\n",
+      "\n",
+      "These are the results:\n",
+      "tname\n",
+      "penicillium_chrysogenum          0.993337\n",
+      "aspergillus_unidentified         0.001732\n",
+      "aspergillus_flavus               0.001333\n",
+      "tuber_brumale                    0.000666\n",
+      "kluyveromyces_marxianus          0.000466\n",
+      "zymoseptoria_tritici             0.000466\n",
+      "pyrenophora_tritici-repentis     0.000333\n",
+      "kluyveromyces_unidentified       0.000267\n",
+      "puccinia_striiformis-tritici     0.000200\n",
+      "cortinarius_globuliformis        0.000133\n",
+      "asteroma_ccl060                  0.000133\n",
+      "oculimacula_yallundae-ccl031     0.000133\n",
+      "clavispora_lusitaniae            0.000133\n",
+      "rhodotorula_mucilaginosa         0.000067\n",
+      "asteroma_ccl068                  0.000067\n",
+      "cladophialophora_unidentified    0.000067\n",
+      "pichia_membranifaciens           0.000067\n",
+      "cryptococcus_zero                0.000067\n",
+      "fusarium_oxysporum               0.000067\n",
+      "kodamaea_ohmeri                  0.000067\n",
+      "meyerozyma_guillermondii         0.000067\n",
+      "oculimacula_yallundae-ccl029     0.000067\n",
+      "diaporthe_unidentified           0.000067\n",
+      "dtype: float64 \n",
+      "\n",
+      "True\n",
+      "##########\n",
+      "\n",
+      "This was the query species: aspergillus_flavus\n",
+      "\n",
+      "These are the results:\n",
+      "tname\n",
+      "aspergillus_flavus              0.997334\n",
+      "aspergillus_unidentified        0.001666\n",
+      "penicillium_chrysogenum         0.000333\n",
+      "entoleuca_unidentified          0.000133\n",
+      "yarrowia_lipolytica             0.000067\n",
+      "yamadazyma_scolyti              0.000067\n",
+      "yamadazyma_mexicana             0.000067\n",
+      "scedosporium_boydii             0.000067\n",
+      "oculimacula_yallundae-ccl031    0.000067\n",
+      "kodamaea_ohmeri                 0.000067\n",
+      "cryptococcus_zero               0.000067\n",
+      "blastobotrys_proliferans        0.000067\n",
+      "dtype: float64 \n",
+      "\n",
+      "True\n",
+      "##########\n",
+      "\n",
+      "This was the query species: aspergillus_niger\n",
+      "\n",
+      "These are the results:\n",
+      "tname\n",
+      "aspergillus_unidentified         0.961055\n",
+      "aspergillus_flavus               0.031568\n",
+      "penicillium_chrysogenum          0.002459\n",
+      "rhodotorula_mucilaginosa         0.000465\n",
+      "dothiorella_vidmadera            0.000465\n",
+      "yamadazyma_scolyti               0.000332\n",
+      "yamadazyma_mexicana              0.000332\n",
+      "entoleuca_unidentified           0.000332\n",
+      "zymoseptoria_tritici             0.000266\n",
+      "tuber_brumale                    0.000266\n",
+      "meyerozyma_guillermondii         0.000199\n",
+      "oculimacula_yallundae-ccl031     0.000199\n",
+      "oculimacula_yallundae-ccl029     0.000199\n",
+      "debaryomyces_unidentified        0.000199\n",
+      "yarrowia_lipolytica              0.000133\n",
+      "cladophialophora_unidentified    0.000133\n",
+      "clavispora_lusitaniae            0.000133\n",
+      "pyrenophora_tritici-repentis     0.000133\n",
+      "quambalaria_cyanescens           0.000133\n",
+      "puccinia_striiformis-tritici     0.000133\n",
+      "galactomyces_geotrichum          0.000066\n",
+      "wickerhamomyces_anomalus         0.000066\n",
+      "kluyveromyces_marxianus          0.000066\n",
+      "diaporthe_ccl067                 0.000066\n",
+      "zygoascus_hellenicus             0.000066\n",
+      "cryptococcus_zero                0.000066\n",
+      "cortinarius_globuliformis        0.000066\n",
+      "scedosporium_boydii              0.000066\n",
+      "pichia_membranifaciens           0.000066\n",
+      "candida_unidentified             0.000066\n",
+      "blastobotrys_proliferans         0.000066\n",
+      "asteroma_ccl068                  0.000066\n",
+      "diaporthe_unidentified           0.000066\n",
+      "dtype: float64 \n",
+      "\n",
+      "True\n",
+      "##########\n",
+      "\n",
+      "This was the query species: pichia_kudriavzevii\n",
+      "\n",
+      "These are the results:\n",
+      "tname\n",
+      "pichia_kudriavzevii              0.995738\n",
+      "pichia_membranifaciens           0.002064\n",
+      "candida_parapsilosis             0.000533\n",
+      "candida_unidentified             0.000333\n",
+      "clavispora_lusitaniae            0.000200\n",
+      "candida_albicans                 0.000133\n",
+      "tuber_brumale                    0.000133\n",
+      "cladophialophora_unidentified    0.000133\n",
+      "galactomyces_geotrichum          0.000133\n",
+      "debaryomyces_unidentified        0.000067\n",
+      "cortinarius_globuliformis        0.000067\n",
+      "yamadazyma_scolyti               0.000067\n",
+      "yamadazyma_mexicana              0.000067\n",
+      "kodamaea_ohmeri                  0.000067\n",
+      "meyerozyma_guillermondii         0.000067\n",
+      "oculimacula_yallundae-ccl031     0.000067\n",
+      "pyrenophora_tritici-repentis     0.000067\n",
+      "kluyveromyces_unidentified       0.000067\n",
+      "dtype: float64 \n",
+      "\n",
+      "True\n",
+      "##########\n",
+      "\n",
+      "This was the query species: pichia_membranifaciens\n",
+      "\n",
+      "These are the results:\n",
+      "tname\n",
+      "pichia_membranifaciens           0.995201\n",
+      "pichia_kudriavzevii              0.001800\n",
+      "candida_parapsilosis             0.000533\n",
+      "kluyveromyces_unidentified       0.000333\n",
+      "yarrowia_lipolytica              0.000267\n",
+      "wickerhamomyces_anomalus         0.000267\n",
+      "kodamaea_ohmeri                  0.000200\n",
+      "meyerozyma_guillermondii         0.000200\n",
+      "candida_albicans                 0.000200\n",
+      "yamadazyma_scolyti               0.000133\n",
+      "kluyveromyces_marxianus          0.000133\n",
+      "debaryomyces_unidentified        0.000133\n",
+      "clavispora_lusitaniae            0.000133\n",
+      "saccharomyces_cerevisiae         0.000133\n",
+      "oculimacula_yallundae-ccl029     0.000067\n",
+      "quambalaria_cyanescens           0.000067\n",
+      "rhodotorula_mucilaginosa         0.000067\n",
+      "galactomyces_geotrichum          0.000067\n",
+      "cladophialophora_unidentified    0.000067\n",
+      "dtype: float64 \n",
+      "\n",
+      "True\n",
+      "##########\n",
+      "\n",
+      "This was the query species: candida_albicans\n",
+      "\n",
+      "These are the results:\n",
+      "tname\n",
+      "candida_albicans                 0.514665\n",
+      "candida_unidentified             0.311764\n",
+      "candida_parapsilosis             0.158939\n",
+      "debaryomyces_unidentified        0.001691\n",
+      "meyerozyma_guillermondii         0.001691\n",
+      "galactomyces_geotrichum          0.001431\n",
+      "kodamaea_ohmeri                  0.000975\n",
+      "yamadazyma_scolyti               0.000845\n",
+      "yamadazyma_mexicana              0.000845\n",
+      "entoleuca_unidentified           0.000780\n",
+      "saccharomyces_cerevisiae         0.000715\n",
+      "kluyveromyces_marxianus          0.000650\n",
+      "tuber_brumale                    0.000650\n",
+      "kluyveromyces_unidentified       0.000650\n",
+      "oculimacula_yallundae-ccl029     0.000585\n",
+      "wickerhamomyces_anomalus         0.000455\n",
+      "clavispora_lusitaniae            0.000390\n",
+      "quambalaria_cyanescens           0.000260\n",
+      "blastobotrys_proliferans         0.000195\n",
+      "pichia_membranifaciens           0.000195\n",
+      "fusarium_oxysporum               0.000195\n",
+      "pichia_kudriavzevii              0.000130\n",
+      "zygoascus_hellenicus             0.000130\n",
+      "pyrenophora_tritici-repentis     0.000130\n",
+      "dothiorella_vidmadera            0.000130\n",
+      "diaporthe_unidentified           0.000130\n",
+      "rhodotorula_mucilaginosa         0.000130\n",
+      "cryptococcus_zero                0.000130\n",
+      "asteroma_ccl068                  0.000065\n",
+      "zymoseptoria_tritici             0.000065\n",
+      "cladophialophora_unidentified    0.000065\n",
+      "cortinarius_globuliformis        0.000065\n",
+      "diaporthe_ccl067                 0.000065\n",
+      "penicillium_chrysogenum          0.000065\n",
+      "yarrowia_lipolytica              0.000065\n",
+      "aspergillus_unidentified         0.000065\n",
+      "dtype: float64 \n",
+      "\n",
+      "True\n",
+      "##########\n",
+      "\n",
+      "This was the query species: candida_parapsilosis\n",
+      "\n",
+      "These are the results:\n",
+      "tname\n",
+      "candida_parapsilosis             0.992413\n",
+      "candida_unidentified             0.001398\n",
+      "candida_albicans                 0.000998\n",
+      "debaryomyces_unidentified        0.000599\n",
+      "meyerozyma_guillermondii         0.000532\n",
+      "kodamaea_ohmeri                  0.000399\n",
+      "pichia_membranifaciens           0.000333\n",
+      "yamadazyma_scolyti               0.000333\n",
+      "kluyveromyces_unidentified       0.000333\n",
+      "tuber_brumale                    0.000266\n",
+      "saccharomyces_cerevisiae         0.000266\n",
+      "kluyveromyces_marxianus          0.000200\n",
+      "galactomyces_geotrichum          0.000200\n",
+      "pichia_kudriavzevii              0.000200\n",
+      "blastobotrys_proliferans         0.000200\n",
+      "yamadazyma_mexicana              0.000200\n",
+      "cortinarius_globuliformis        0.000133\n",
+      "zygoascus_hellenicus             0.000133\n",
+      "dothiorella_vidmadera            0.000133\n",
+      "diaporthe_unidentified           0.000067\n",
+      "cryptococcus_zero                0.000067\n",
+      "fusarium_oxysporum               0.000067\n",
+      "clavispora_lusitaniae            0.000067\n",
+      "cladophialophora_unidentified    0.000067\n",
+      "yarrowia_lipolytica              0.000067\n",
+      "oculimacula_yallundae-ccl029     0.000067\n",
+      "rhodotorula_mucilaginosa         0.000067\n",
+      "wickerhamomyces_anomalus         0.000067\n",
+      "asteroma_ccl060                  0.000067\n",
+      "aspergillus_unidentified         0.000067\n",
+      "dtype: float64 \n",
+      "\n",
+      "True\n",
+      "##########\n",
+      "\n",
+      "This was the query species: candida_orthopsilosis\n",
+      "\n",
+      "These are the results:\n",
+      "tname\n",
+      "candida_parapsilosis             0.964596\n",
+      "meyerozyma_guillermondii         0.015779\n",
+      "candida_unidentified             0.005171\n",
+      "candida_albicans                 0.004177\n",
+      "debaryomyces_unidentified        0.001392\n",
+      "tuber_brumale                    0.000994\n",
+      "yamadazyma_scolyti               0.000928\n",
+      "yamadazyma_mexicana              0.000729\n",
+      "wickerhamomyces_anomalus         0.000663\n",
+      "galactomyces_geotrichum          0.000663\n",
+      "kodamaea_ohmeri                  0.000597\n",
+      "kluyveromyces_unidentified       0.000530\n",
+      "blastobotrys_proliferans         0.000464\n",
+      "saccharomyces_cerevisiae         0.000398\n",
+      "zygoascus_hellenicus             0.000398\n",
+      "clavispora_lusitaniae            0.000331\n",
+      "pichia_membranifaciens           0.000199\n",
+      "oculimacula_yallundae-ccl029     0.000199\n",
+      "kluyveromyces_marxianus          0.000199\n",
+      "yarrowia_lipolytica              0.000199\n",
+      "puccinia_striiformis-tritici     0.000133\n",
+      "cortinarius_globuliformis        0.000133\n",
+      "oculimacula_yallundae-ccl031     0.000133\n",
+      "entoleuca_unidentified           0.000133\n",
+      "cladophialophora_unidentified    0.000133\n",
+      "pichia_kudriavzevii              0.000133\n",
+      "zymoseptoria_tritici             0.000066\n",
+      "cryptococcus_zero                0.000066\n",
+      "diaporthe_ccl067                 0.000066\n",
+      "diaporthe_unidentified           0.000066\n",
+      "fusarium_oxysporum               0.000066\n",
+      "pyrenophora_tritici-repentis     0.000066\n",
+      "quambalaria_cyanescens           0.000066\n",
+      "scedosporium_boydii              0.000066\n",
+      "aspergillus_flavus               0.000066\n",
+      "dtype: float64 \n",
+      "\n",
+      "True\n",
+      "##########\n",
+      "\n",
+      "This was the query species: candida_metapsilosis\n",
+      "\n",
+      "These are the results:\n",
+      "tname\n",
+      "candida_parapsilosis             0.982146\n",
+      "candida_albicans                 0.003916\n",
+      "candida_unidentified             0.003783\n",
+      "meyerozyma_guillermondii         0.002057\n",
+      "debaryomyces_unidentified        0.001327\n",
+      "kodamaea_ohmeri                  0.001062\n",
+      "yamadazyma_mexicana              0.000597\n",
+      "galactomyces_geotrichum          0.000531\n",
+      "saccharomyces_cerevisiae         0.000531\n",
+      "clavispora_lusitaniae            0.000531\n",
+      "yamadazyma_scolyti               0.000398\n",
+      "tuber_brumale                    0.000332\n",
+      "pyrenophora_tritici-repentis     0.000332\n",
+      "blastobotrys_proliferans         0.000332\n",
+      "wickerhamomyces_anomalus         0.000265\n",
+      "diaporthe_unidentified           0.000199\n",
+      "kluyveromyces_unidentified       0.000199\n",
+      "kluyveromyces_marxianus          0.000199\n",
+      "oculimacula_yallundae-ccl029     0.000199\n",
+      "fusarium_oxysporum               0.000133\n",
+      "yarrowia_lipolytica              0.000133\n",
+      "pichia_kudriavzevii              0.000133\n",
+      "rhodotorula_mucilaginosa         0.000133\n",
+      "asteroma_ccl068                  0.000066\n",
+      "asteroma_ccl060                  0.000066\n",
+      "zymoseptoria_tritici             0.000066\n",
+      "cladophialophora_unidentified    0.000066\n",
+      "entoleuca_unidentified           0.000066\n",
+      "oculimacula_yallundae-ccl031     0.000066\n",
+      "scedosporium_boydii              0.000066\n",
+      "aspergillus_flavus               0.000066\n",
+      "dtype: float64 \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "###this is running against a database that have ['Candida_orthopsilosis', 'Candida_metapsilosis', 'Aspergillus_niger'] deleted\n",
+    "for species, hit_fn in sub_db_mapping_fn.items():\n",
+    "    mapping_results(hit_fn, species)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Pull in mapping results and analyse them at all available levels"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### idea\n",
+    "\n",
+    "* pull in query taxid as a dictionary\n",
+    "* assign taxid for each tname species from minimap2\n",
+    "* generate a summary dictionary that checks concordance at each taxonmic rank"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def pull_mapping_results(fn):\n",
+    "    \"\"\"\n",
+    "    Takes a minimap2 paf and reads it in with the first 12 columns. Ignores the rest.\n",
+    "    Filters for each read the best hit on mquality first taking the highest value.\n",
+    "    Filters for each read by the number of nmatches in the second step.\n",
+    "    Returns a dataframe that has the tnames as index and the counts of hits as column 'count'.\n",
+    "    The dataframe has also the taxrank columns ['k', 'p', 'c', 'o', 'f', 'g', 's'] that are all False to start with.\n",
+    "    \"\"\"\n",
+    "    min_header = ['qseqid', 'qlen', 'qstart', 'qstop', 'strand', 'tname', 'tlen', 'tstart', 'tend', 'nmatch', 'alen', 'mquality']\n",
+    "    tmp_df = pd.read_csv(fn, sep='\\t', header = None, usecols=[x for x in range(0,12)], names=min_header)\n",
+    "    sub_df = tmp_df[tmp_df['mquality'] == tmp_df.groupby('qseqid')['mquality'].transform(max)].reset_index(drop=True)\n",
+    "    sub_df = sub_df[sub_df['nmatch'] == sub_df.groupby('qseqid')['nmatch'].transform(max)].reset_index(drop=True)\n",
+    "    hit_df = pd.DataFrame(sub_df.groupby('tname')['mquality'].count().tolist(), sub_df.groupby('tname')['mquality'].count().index, columns=['count'])\n",
+    "    hit_df.sort_values(by='count', ascending=False, inplace=True)\n",
+    "    for key in ['k', 'p', 'c', 'o', 'f', 'g', 's']:\n",
+    "        hit_df[key] = False\n",
+    "    return hit_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def getquery_taxfileid(refdf_fn, species):\n",
+    "    \"\"\"\n",
+    "    Takes the reference dataframe filename and the species name.\n",
+    "    Returns the taxfileid, which is the date/flowcellid (column 0 value) of the ref_df.\n",
+    "    \"\"\"\n",
+    "    ref_df = pd.read_csv(refdf_fn)\n",
+    "    ref_df['name_species'] = ref_df['genus'] +\"_\"+ ref_df['species']\n",
+    "    return ref_df[ref_df.name_species == species].iloc[:,0].values[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_taxid_dict(taxid_fn, taxfileid):\n",
+    "    \"\"\"\n",
+    "    Takes a taxonomy assignment file filename in the Qiime format and a taxonomic identifier.\n",
+    "    Returns the a dictionary with the taxonomic assignment at each rank.\n",
+    "    \"\"\"\n",
+    "    tax_dict = {}\n",
+    "    with open(taxid_fn, 'r') as fh:\n",
+    "        for line in fh:\n",
+    "            if line.startswith(taxfileid):\n",
+    "                taxrankids = line.rstrip().split('\\t')[1].split(';')\n",
+    "                for taxrank in taxrankids:\n",
+    "                    tax_dict[taxrank.split('__')[0]] = taxrank.split('__')[1]\n",
+    "    return tax_dict"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def assign_taxranks_results(mapping_df, tax_fn, ref_df_fn = False):\n",
+    "    \"\"\"\n",
+    "    This function assigns the taxonomic ranks for each hit in the mapping results dataframe.\n",
+    "    It takes a mapping_df, taxonomy assignment file, and if required a reference dataframe filename.\n",
+    "    Returns the mapping dataframe with assignment. \n",
+    "    \"\"\"\n",
+    "    for tname in mapping_df.index:\n",
+    "        if ref_df_fn:\n",
+    "            tmp_taxfileid = getquery_taxfileid(ref_df_fn, tname)\n",
+    "        else:\n",
+    "            tmp_taxfileid = tname\n",
+    "        tmp_tax_dict = get_taxid_dict(tax_fn, tmp_taxfileid)\n",
+    "        for key, value in tmp_tax_dict.items():\n",
+    "            mapping_df.loc[tname, key] = value\n",
+    "    return mapping_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_accuracy_dict(mapping_df, query_tax_dict):\n",
+    "    \"\"\"\n",
+    "    Summarieses the mapping accuracy of the mapping results at all taxonomic ranks.\n",
+    "    Takes the mapping_df with taxnomonic assignments and a taxnomic dictionary of the known query.\n",
+    "    Returns an accuracy dictionary for each taxnomic rank ['k', 'p', 'c', 'o', 'f', 'g', 's']. \n",
+    "    Right now this function takes a qiime tax \n",
+    "    \"\"\"\n",
+    "    accuracy_dict = {}\n",
+    "    total_count = mapping_df['count'].sum()\n",
+    "    for tax_rank in ['k', 'p', 'c', 'o', 'f', 'g', 's']:\n",
+    "        hit_count = mapping_df[mapping_df[tax_rank] == query_tax_dict[tax_rank]]['count'].sum()\n",
+    "            \n",
+    "        accuracy_dict[tax_rank] = hit_count/total_count\n",
+    "    return accuracy_dict"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "###Test out the summary results statistic for a single mapping result\n",
+    "species = 'penicillium_chrysogenum'\n",
+    "mapping_results = pull_mapping_results(sub_db_mapping_fn[species])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "###Assign the data taxonomics ranks for all the results\n",
+    "mapping_results = assign_taxranks_results(mapping_results, taxonomy_file_fn, ref_df_fn=reference_dataframe_fn)\n",
+    "\n",
+    "taxfileid = getquery_taxfileid(reference_dataframe_fn, species)\n",
+    "\n",
+    "query_tax_dict = get_taxid_dict(taxonomy_file_fn, taxfileid)\n",
+    "\n",
+    "sensitivity_dict = get_accuracy_dict(mapping_results, query_tax_dict)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'k': 1.0,\n",
+       " 'p': 0.9995335820895522,\n",
+       " 'c': 0.9964685501066098,\n",
+       " 'o': 0.9964019189765458,\n",
+       " 'f': 0.9964019189765458,\n",
+       " 'g': 0.9933368869936035,\n",
+       " 's': 0.9933368869936035}"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sensitivity_dict"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Test run on the quiime2 Database\n",
+    "\n",
+    "##### Prep on the command line\n",
+    "\n",
+    "cp sh_refs_qiime_ver8_dynamic_02.02.2019.fasta /media/WorkingStorage/ben.working/students/tavish/analysis/qiime2/db/.  \n",
+    "cp sh_taxonomy_qiime_ver8_dynamic_02.02.2019.txt /media/WorkingStorage/ben.working/students/tavish/analysis/qiime2/db/.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 90,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def pull_mapping_results_v2(fn):\n",
+    "    \"\"\"\n",
+    "    Takes a minimap2 paf and reads it in with the first 12 columns. Ignores the rest.\n",
+    "    Filters for each read the best hit on mquality first taking the highest value.\n",
+    "    Filters for each read by the number of nmatches in the second step.\n",
+    "    Returns a dataframe that has the tnames as index and the counts of hits as column 'count'.\n",
+    "    The dataframe has also the taxrank columns ['k', 'p', 'c', 'o', 'f', 'g', 's'] that are all False to start with.\n",
+    "    \"\"\"\n",
+    "    min_header = ['qseqid', 'qlen', 'qstart', 'qstop', 'strand', 'tname', 'tlen', 'tstart', 'tend', 'nmatch', 'alen', 'mquality']\n",
+    "    tmp_df = pd.read_csv(fn, sep='\\t', header = None, usecols=[x for x in range(0,12)], names=min_header)\n",
+    "    sub_df = tmp_df[tmp_df['mquality'] == tmp_df.groupby('qseqid')['mquality'].transform(max)].reset_index(drop=True)\n",
+    "    #sub_df = sub_df[sub_df['nmatch'] == sub_df.groupby('qseqid')['nmatch'].transform(max)].reset_index(drop=True)\n",
+    "    hit_df = pd.DataFrame(sub_df.groupby('tname')['mquality'].count().tolist(), sub_df.groupby('tname')['mquality'].count().index, columns=['count'])\n",
+    "    hit_df.sort_values(by='count', ascending=False, inplace=True)\n",
+    "    for key in ['k', 'p', 'c', 'o', 'f', 'g', 's']:\n",
+    "        hit_df[key] = False\n",
+    "        tmp_df[key] = False\n",
+    "    return hit_df, tmp_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/media/WorkingStorage/ben.working/students/tavish/scripts/notebooks'"
+      ]
+     },
+     "execution_count": 48,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "os.path.abspath(os.curdir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "qiime_db_fn = os.path.abspath('../../analysis/qiime2/db/sh_refs_qiime_ver8_dynamic_02.02.2019.fasta')\n",
+    "qiime_tax_fn = os.path.abspath('../../analysis/qiime2/db/sh_taxonomy_qiime_ver8_dynamic_02.02.2019.txt')\n",
+    "threads = 10\n",
+    "QIIME_DIR = os.path.abspath('../../analysis/qiime2/')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "##mapping folder\n",
+    "mapping_dir = os.path.join(QIIME_DIR, os.path.basename(qiime_db_fn).replace('.fasta', '').replace('.','_'))\n",
+    "if not os.path.exists(mapping_dir):\n",
+    "    os.mkdir(mapping_dir)\n",
+    "subsampling_dir = os.path.join(QIIME_DIR, 'subsamplereads')\n",
+    "if not os.path.exists(subsampling_dir):\n",
+    "    os.mkdir(subsampling_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run on test species 'penicillium_chrysogenum'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 93,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ":(check one reformat.sh samplereadstarget=20000 in=/media/MassStorage/tmp/TE/honours/analysis/Length_Filtered/20171103_FAH15473/barcode10/length_restricted_for_use.fasta out=/media/WorkingStorage/ben.working/students/tavish/analysis/qiime2/subsamplereads/penicillium_chrysogenum.20000.fasta!!\n",
+      "\n",
+      ":)Completed minimap2 -x map-ont -t 10 /media/WorkingStorage/ben.working/students/tavish/analysis/qiime2/db/sh_refs_qiime_ver8_99_02.02.2019.fasta /media/WorkingStorage/ben.working/students/tavish/analysis/qiime2/subsamplereads/penicillium_chrysogenum.20000.fasta -o /media/WorkingStorage/ben.working/students/tavish/analysis/qiime2/sh_refs_qiime_ver8_99_02_02_2019/sh_refs_qiime_ver8_99_02.02.2019.penicillium_chrysogenum.minimap2.paf\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "#subsample tests species\n",
+    "fn_subsampling = {}\n",
+    "test_species = ['penicillium_chrysogenum']\n",
+    "for x in test_species:\n",
+    "    fn_subsampling[x] = (ref_df[(ref_df['species'] == x.split('_')[1]) & (ref_df['genus'] == x.split('_')[0])]['path for use'].tolist()[0])\n",
+    "    fn_subsampling[x] = os.path.join(INPUT_BASEDIR, fn_subsampling[x])\n",
+    "\n",
+    "sub_reads_fn = {}\n",
+    "n_reads = 20000\n",
+    "for key, value in fn_subsampling.items():\n",
+    "    species = key\n",
+    "    in_fn = value\n",
+    "    out_fn = os.path.join(subsampling_dir, F'{species}.{n_reads}.fasta')\n",
+    "    subsamplereads(in_fn, out_fn, n_reads)\n",
+    "    sub_reads_fn[species] = out_fn\n",
+    "\n",
+    "###Map the reads\n",
+    "db_fn = qiime_db_fn\n",
+    "sub_db_mapping_fn = {}\n",
+    "for species, fasta_fn in sub_reads_fn.items():\n",
+    "    db_name = os.path.basename(db_fn).replace('.fasta', '')\n",
+    "    out_fn = os.path.join(mapping_dir, F\"{db_name}.{species}.minimap2.paf\")\n",
+    "    sub_db_mapping_fn[species] = out_fn\n",
+    "    minimapmapping(fasta_fn, db_fn, out_fn, threads)\n",
+    "\n",
+    "###Test out the summary results statistic for a single mapping result\n",
+    "species = 'penicillium_chrysogenum'\n",
+    "mapping_results , full_results_df = pull_mapping_results_v2(sub_db_mapping_fn[species])\n",
+    "mapping_results = assign_taxranks_results(mapping_results, qiime_tax_fn)\n",
+    "taxfileid = getquery_taxfileid(reference_dataframe_fn, species)\n",
+    "query_tax_dict = get_taxid_dict(taxonomy_file_fn, taxfileid)\n",
+    "###fix family level for 'penicillium_chrysogenum'\n",
+    "query_tax_dict['f'] = 'Trichomonascaceae'\n",
+    "sensitivity_dict = get_accuracy_dict(mapping_results, query_tax_dict)\n",
+    "\n",
+    "\n",
+    "full_results_df.index = full_results_df.tname\n",
+    "###Also look at the full results dataframe to explore results a bit more\n",
+    "for tname in full_results_df.tname.unique():\n",
+    "\n",
+    "    tmp_tax_dict = get_taxid_dict(qiime_tax_fn, tname)\n",
+    "    for key, value in tmp_tax_dict.items():\n",
+    "        full_results_df.loc[tname, key] = value"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'k': 1.0,\n",
+       " 'p': 0.8811273411596021,\n",
+       " 'c': 0.18675508558114526,\n",
+       " 'o': 0.18594856169907698,\n",
+       " 'f': 0.004391074469038444,\n",
+       " 'g': 0.08275831167667354,\n",
+       " 's': 0.003987812528004301}"
+      ]
+     },
+     "execution_count": 85,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sensitivity_dict "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 89,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>qseqid</th>\n",
+       "      <th>qlen</th>\n",
+       "      <th>qstart</th>\n",
+       "      <th>qstop</th>\n",
+       "      <th>strand</th>\n",
+       "      <th>tname</th>\n",
+       "      <th>tlen</th>\n",
+       "      <th>tstart</th>\n",
+       "      <th>tend</th>\n",
+       "      <th>nmatch</th>\n",
+       "      <th>alen</th>\n",
+       "      <th>mquality</th>\n",
+       "      <th>k</th>\n",
+       "      <th>p</th>\n",
+       "      <th>c</th>\n",
+       "      <th>o</th>\n",
+       "      <th>f</th>\n",
+       "      <th>g</th>\n",
+       "      <th>s</th>\n",
+       "      <th>count</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>tname</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>SH1649638.08FU_UDB016769_refs</th>\n",
+       "      <td>fa3febf1-c473-442a-b9be-d8124c4dfd86</td>\n",
+       "      <td>2927</td>\n",
+       "      <td>165</td>\n",
+       "      <td>514</td>\n",
+       "      <td>-</td>\n",
+       "      <td>SH1649638.08FU_UDB016769_refs</td>\n",
+       "      <td>1720</td>\n",
+       "      <td>1270</td>\n",
+       "      <td>1639</td>\n",
+       "      <td>68</td>\n",
+       "      <td>370</td>\n",
+       "      <td>18</td>\n",
+       "      <td>Fungi</td>\n",
+       "      <td>Basidiomycota</td>\n",
+       "      <td>Agaricomycetes</td>\n",
+       "      <td>Thelephorales</td>\n",
+       "      <td>Thelephoraceae</td>\n",
+       "      <td>Tomentella</td>\n",
+       "      <td>unidentified</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>SH1654757.08FU_UDB014954_reps</th>\n",
+       "      <td>fa3febf1-c473-442a-b9be-d8124c4dfd86</td>\n",
+       "      <td>2927</td>\n",
+       "      <td>343</td>\n",
+       "      <td>803</td>\n",
+       "      <td>-</td>\n",
+       "      <td>SH1654757.08FU_UDB014954_reps</td>\n",
+       "      <td>1390</td>\n",
+       "      <td>812</td>\n",
+       "      <td>1293</td>\n",
+       "      <td>68</td>\n",
+       "      <td>482</td>\n",
+       "      <td>28</td>\n",
+       "      <td>Fungi</td>\n",
+       "      <td>Ascomycota</td>\n",
+       "      <td>Orbiliomycetes</td>\n",
+       "      <td>Orbiliales</td>\n",
+       "      <td>unidentified</td>\n",
+       "      <td>unidentified</td>\n",
+       "      <td>unidentified</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>SH1680040.08FU_KC992945_refs_singleton</th>\n",
+       "      <td>fa3febf1-c473-442a-b9be-d8124c4dfd86</td>\n",
+       "      <td>2927</td>\n",
+       "      <td>343</td>\n",
+       "      <td>514</td>\n",
+       "      <td>-</td>\n",
+       "      <td>SH1680040.08FU_KC992945_refs_singleton</td>\n",
+       "      <td>1573</td>\n",
+       "      <td>1280</td>\n",
+       "      <td>1466</td>\n",
+       "      <td>53</td>\n",
+       "      <td>187</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Fungi</td>\n",
+       "      <td>Basidiomycota</td>\n",
+       "      <td>Agaricomycetes</td>\n",
+       "      <td>Agaricales</td>\n",
+       "      <td>Agaricaceae</td>\n",
+       "      <td>Cystoagaricus</td>\n",
+       "      <td>Cystoagaricus_hirtosquamulosus</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>SH1566136.08FU_KC992951_refs</th>\n",
+       "      <td>fa3febf1-c473-442a-b9be-d8124c4dfd86</td>\n",
+       "      <td>2927</td>\n",
+       "      <td>343</td>\n",
+       "      <td>514</td>\n",
+       "      <td>-</td>\n",
+       "      <td>SH1566136.08FU_KC992951_refs</td>\n",
+       "      <td>1588</td>\n",
+       "      <td>1296</td>\n",
+       "      <td>1482</td>\n",
+       "      <td>53</td>\n",
+       "      <td>187</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Fungi</td>\n",
+       "      <td>Basidiomycota</td>\n",
+       "      <td>Agaricomycetes</td>\n",
+       "      <td>Agaricales</td>\n",
+       "      <td>Psathyrellaceae</td>\n",
+       "      <td>Lacrymaria</td>\n",
+       "      <td>Lacrymaria_subcinnamomea</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>SH1896017.08FU_AF034454_refs</th>\n",
+       "      <td>fa3febf1-c473-442a-b9be-d8124c4dfd86</td>\n",
+       "      <td>2927</td>\n",
+       "      <td>1448</td>\n",
+       "      <td>1518</td>\n",
+       "      <td>-</td>\n",
+       "      <td>SH1896017.08FU_AF034454_refs</td>\n",
+       "      <td>506</td>\n",
+       "      <td>126</td>\n",
+       "      <td>193</td>\n",
+       "      <td>41</td>\n",
+       "      <td>70</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Fungi</td>\n",
+       "      <td>Ascomycota</td>\n",
+       "      <td>Eurotiomycetes</td>\n",
+       "      <td>Eurotiales</td>\n",
+       "      <td>Aspergillaceae</td>\n",
+       "      <td>Penicillium</td>\n",
+       "      <td>Penicillium_turbatum</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>SH2190163.08FU_AF033485_refs</th>\n",
+       "      <td>ed39c3c6-0c0f-4ab6-af60-a6af445b7ac0</td>\n",
+       "      <td>2983</td>\n",
+       "      <td>1538</td>\n",
+       "      <td>1684</td>\n",
+       "      <td>-</td>\n",
+       "      <td>SH2190163.08FU_AF033485_refs</td>\n",
+       "      <td>505</td>\n",
+       "      <td>15</td>\n",
+       "      <td>159</td>\n",
+       "      <td>45</td>\n",
+       "      <td>147</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Fungi</td>\n",
+       "      <td>Ascomycota</td>\n",
+       "      <td>Eurotiomycetes</td>\n",
+       "      <td>Eurotiales</td>\n",
+       "      <td>Aspergillaceae</td>\n",
+       "      <td>Penicillium</td>\n",
+       "      <td>Penicillium_malodoratum</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>SH2189971.08FU_JX997101_refs</th>\n",
+       "      <td>ed39c3c6-0c0f-4ab6-af60-a6af445b7ac0</td>\n",
+       "      <td>2983</td>\n",
+       "      <td>1538</td>\n",
+       "      <td>1684</td>\n",
+       "      <td>-</td>\n",
+       "      <td>SH2189971.08FU_JX997101_refs</td>\n",
+       "      <td>496</td>\n",
+       "      <td>4</td>\n",
+       "      <td>149</td>\n",
+       "      <td>45</td>\n",
+       "      <td>148</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Fungi</td>\n",
+       "      <td>Ascomycota</td>\n",
+       "      <td>Eurotiomycetes</td>\n",
+       "      <td>Eurotiales</td>\n",
+       "      <td>Aspergillaceae</td>\n",
+       "      <td>Penicillium</td>\n",
+       "      <td>Penicillium_nalgiovense</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>SH1654757.08FU_UDB014954_reps</th>\n",
+       "      <td>ed3f13ef-aae3-44b4-b5b3-ec4c103e4b44</td>\n",
+       "      <td>2750</td>\n",
+       "      <td>1678</td>\n",
+       "      <td>2396</td>\n",
+       "      <td>+</td>\n",
+       "      <td>SH1654757.08FU_UDB014954_reps</td>\n",
+       "      <td>1390</td>\n",
+       "      <td>519</td>\n",
+       "      <td>1282</td>\n",
+       "      <td>59</td>\n",
+       "      <td>763</td>\n",
+       "      <td>12</td>\n",
+       "      <td>Fungi</td>\n",
+       "      <td>Ascomycota</td>\n",
+       "      <td>Orbiliomycetes</td>\n",
+       "      <td>Orbiliales</td>\n",
+       "      <td>unidentified</td>\n",
+       "      <td>unidentified</td>\n",
+       "      <td>unidentified</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>SH1732842.08FU_FJ430779_refs_singleton</th>\n",
+       "      <td>ed3f13ef-aae3-44b4-b5b3-ec4c103e4b44</td>\n",
+       "      <td>2750</td>\n",
+       "      <td>228</td>\n",
+       "      <td>593</td>\n",
+       "      <td>+</td>\n",
+       "      <td>SH1732842.08FU_FJ430779_refs_singleton</td>\n",
+       "      <td>1661</td>\n",
+       "      <td>651</td>\n",
+       "      <td>1042</td>\n",
+       "      <td>45</td>\n",
+       "      <td>391</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Fungi</td>\n",
+       "      <td>Ascomycota</td>\n",
+       "      <td>Leotiomycetes</td>\n",
+       "      <td>Helotiales</td>\n",
+       "      <td>Helotiaceae</td>\n",
+       "      <td>Acidea</td>\n",
+       "      <td>Acidea_extrema</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>SH1563342.08FU_UDB028691_reps</th>\n",
+       "      <td>ed3f13ef-aae3-44b4-b5b3-ec4c103e4b44</td>\n",
+       "      <td>2750</td>\n",
+       "      <td>228</td>\n",
+       "      <td>593</td>\n",
+       "      <td>+</td>\n",
+       "      <td>SH1563342.08FU_UDB028691_reps</td>\n",
+       "      <td>3526</td>\n",
+       "      <td>1183</td>\n",
+       "      <td>1574</td>\n",
+       "      <td>45</td>\n",
+       "      <td>391</td>\n",
+       "      <td>0</td>\n",
+       "      <td>Fungi</td>\n",
+       "      <td>Ascomycota</td>\n",
+       "      <td>Leotiomycetes</td>\n",
+       "      <td>Helotiales</td>\n",
+       "      <td>Myxotrichaceae</td>\n",
+       "      <td>Oidiodendron</td>\n",
+       "      <td>unidentified</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>163332 rows × 20 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                                      qseqid  \\\n",
+       "tname                                                                          \n",
+       "SH1649638.08FU_UDB016769_refs           fa3febf1-c473-442a-b9be-d8124c4dfd86   \n",
+       "SH1654757.08FU_UDB014954_reps           fa3febf1-c473-442a-b9be-d8124c4dfd86   \n",
+       "SH1680040.08FU_KC992945_refs_singleton  fa3febf1-c473-442a-b9be-d8124c4dfd86   \n",
+       "SH1566136.08FU_KC992951_refs            fa3febf1-c473-442a-b9be-d8124c4dfd86   \n",
+       "SH1896017.08FU_AF034454_refs            fa3febf1-c473-442a-b9be-d8124c4dfd86   \n",
+       "...                                                                      ...   \n",
+       "SH2190163.08FU_AF033485_refs            ed39c3c6-0c0f-4ab6-af60-a6af445b7ac0   \n",
+       "SH2189971.08FU_JX997101_refs            ed39c3c6-0c0f-4ab6-af60-a6af445b7ac0   \n",
+       "SH1654757.08FU_UDB014954_reps           ed3f13ef-aae3-44b4-b5b3-ec4c103e4b44   \n",
+       "SH1732842.08FU_FJ430779_refs_singleton  ed3f13ef-aae3-44b4-b5b3-ec4c103e4b44   \n",
+       "SH1563342.08FU_UDB028691_reps           ed3f13ef-aae3-44b4-b5b3-ec4c103e4b44   \n",
+       "\n",
+       "                                        qlen  qstart  qstop strand  \\\n",
+       "tname                                                                \n",
+       "SH1649638.08FU_UDB016769_refs           2927     165    514      -   \n",
+       "SH1654757.08FU_UDB014954_reps           2927     343    803      -   \n",
+       "SH1680040.08FU_KC992945_refs_singleton  2927     343    514      -   \n",
+       "SH1566136.08FU_KC992951_refs            2927     343    514      -   \n",
+       "SH1896017.08FU_AF034454_refs            2927    1448   1518      -   \n",
+       "...                                      ...     ...    ...    ...   \n",
+       "SH2190163.08FU_AF033485_refs            2983    1538   1684      -   \n",
+       "SH2189971.08FU_JX997101_refs            2983    1538   1684      -   \n",
+       "SH1654757.08FU_UDB014954_reps           2750    1678   2396      +   \n",
+       "SH1732842.08FU_FJ430779_refs_singleton  2750     228    593      +   \n",
+       "SH1563342.08FU_UDB028691_reps           2750     228    593      +   \n",
+       "\n",
+       "                                                                         tname  \\\n",
+       "tname                                                                            \n",
+       "SH1649638.08FU_UDB016769_refs                    SH1649638.08FU_UDB016769_refs   \n",
+       "SH1654757.08FU_UDB014954_reps                    SH1654757.08FU_UDB014954_reps   \n",
+       "SH1680040.08FU_KC992945_refs_singleton  SH1680040.08FU_KC992945_refs_singleton   \n",
+       "SH1566136.08FU_KC992951_refs                      SH1566136.08FU_KC992951_refs   \n",
+       "SH1896017.08FU_AF034454_refs                      SH1896017.08FU_AF034454_refs   \n",
+       "...                                                                        ...   \n",
+       "SH2190163.08FU_AF033485_refs                      SH2190163.08FU_AF033485_refs   \n",
+       "SH2189971.08FU_JX997101_refs                      SH2189971.08FU_JX997101_refs   \n",
+       "SH1654757.08FU_UDB014954_reps                    SH1654757.08FU_UDB014954_reps   \n",
+       "SH1732842.08FU_FJ430779_refs_singleton  SH1732842.08FU_FJ430779_refs_singleton   \n",
+       "SH1563342.08FU_UDB028691_reps                    SH1563342.08FU_UDB028691_reps   \n",
+       "\n",
+       "                                        tlen  tstart  tend  nmatch  alen  \\\n",
+       "tname                                                                      \n",
+       "SH1649638.08FU_UDB016769_refs           1720    1270  1639      68   370   \n",
+       "SH1654757.08FU_UDB014954_reps           1390     812  1293      68   482   \n",
+       "SH1680040.08FU_KC992945_refs_singleton  1573    1280  1466      53   187   \n",
+       "SH1566136.08FU_KC992951_refs            1588    1296  1482      53   187   \n",
+       "SH1896017.08FU_AF034454_refs             506     126   193      41    70   \n",
+       "...                                      ...     ...   ...     ...   ...   \n",
+       "SH2190163.08FU_AF033485_refs             505      15   159      45   147   \n",
+       "SH2189971.08FU_JX997101_refs             496       4   149      45   148   \n",
+       "SH1654757.08FU_UDB014954_reps           1390     519  1282      59   763   \n",
+       "SH1732842.08FU_FJ430779_refs_singleton  1661     651  1042      45   391   \n",
+       "SH1563342.08FU_UDB028691_reps           3526    1183  1574      45   391   \n",
+       "\n",
+       "                                        mquality      k              p  \\\n",
+       "tname                                                                    \n",
+       "SH1649638.08FU_UDB016769_refs                 18  Fungi  Basidiomycota   \n",
+       "SH1654757.08FU_UDB014954_reps                 28  Fungi     Ascomycota   \n",
+       "SH1680040.08FU_KC992945_refs_singleton         0  Fungi  Basidiomycota   \n",
+       "SH1566136.08FU_KC992951_refs                   0  Fungi  Basidiomycota   \n",
+       "SH1896017.08FU_AF034454_refs                   1  Fungi     Ascomycota   \n",
+       "...                                          ...    ...            ...   \n",
+       "SH2190163.08FU_AF033485_refs                   0  Fungi     Ascomycota   \n",
+       "SH2189971.08FU_JX997101_refs                   0  Fungi     Ascomycota   \n",
+       "SH1654757.08FU_UDB014954_reps                 12  Fungi     Ascomycota   \n",
+       "SH1732842.08FU_FJ430779_refs_singleton         0  Fungi     Ascomycota   \n",
+       "SH1563342.08FU_UDB028691_reps                  0  Fungi     Ascomycota   \n",
+       "\n",
+       "                                                     c              o  \\\n",
+       "tname                                                                   \n",
+       "SH1649638.08FU_UDB016769_refs           Agaricomycetes  Thelephorales   \n",
+       "SH1654757.08FU_UDB014954_reps           Orbiliomycetes     Orbiliales   \n",
+       "SH1680040.08FU_KC992945_refs_singleton  Agaricomycetes     Agaricales   \n",
+       "SH1566136.08FU_KC992951_refs            Agaricomycetes     Agaricales   \n",
+       "SH1896017.08FU_AF034454_refs            Eurotiomycetes     Eurotiales   \n",
+       "...                                                ...            ...   \n",
+       "SH2190163.08FU_AF033485_refs            Eurotiomycetes     Eurotiales   \n",
+       "SH2189971.08FU_JX997101_refs            Eurotiomycetes     Eurotiales   \n",
+       "SH1654757.08FU_UDB014954_reps           Orbiliomycetes     Orbiliales   \n",
+       "SH1732842.08FU_FJ430779_refs_singleton   Leotiomycetes     Helotiales   \n",
+       "SH1563342.08FU_UDB028691_reps            Leotiomycetes     Helotiales   \n",
+       "\n",
+       "                                                      f              g  \\\n",
+       "tname                                                                    \n",
+       "SH1649638.08FU_UDB016769_refs            Thelephoraceae     Tomentella   \n",
+       "SH1654757.08FU_UDB014954_reps              unidentified   unidentified   \n",
+       "SH1680040.08FU_KC992945_refs_singleton      Agaricaceae  Cystoagaricus   \n",
+       "SH1566136.08FU_KC992951_refs            Psathyrellaceae     Lacrymaria   \n",
+       "SH1896017.08FU_AF034454_refs             Aspergillaceae    Penicillium   \n",
+       "...                                                 ...            ...   \n",
+       "SH2190163.08FU_AF033485_refs             Aspergillaceae    Penicillium   \n",
+       "SH2189971.08FU_JX997101_refs             Aspergillaceae    Penicillium   \n",
+       "SH1654757.08FU_UDB014954_reps              unidentified   unidentified   \n",
+       "SH1732842.08FU_FJ430779_refs_singleton      Helotiaceae         Acidea   \n",
+       "SH1563342.08FU_UDB028691_reps            Myxotrichaceae   Oidiodendron   \n",
+       "\n",
+       "                                                                     s  count  \n",
+       "tname                                                                          \n",
+       "SH1649638.08FU_UDB016769_refs                             unidentified      1  \n",
+       "SH1654757.08FU_UDB014954_reps                             unidentified      1  \n",
+       "SH1680040.08FU_KC992945_refs_singleton  Cystoagaricus_hirtosquamulosus      1  \n",
+       "SH1566136.08FU_KC992951_refs                  Lacrymaria_subcinnamomea      1  \n",
+       "SH1896017.08FU_AF034454_refs                      Penicillium_turbatum      1  \n",
+       "...                                                                ...    ...  \n",
+       "SH2190163.08FU_AF033485_refs                   Penicillium_malodoratum      1  \n",
+       "SH2189971.08FU_JX997101_refs                   Penicillium_nalgiovense      1  \n",
+       "SH1654757.08FU_UDB014954_reps                             unidentified      1  \n",
+       "SH1732842.08FU_FJ430779_refs_singleton                  Acidea_extrema      1  \n",
+       "SH1563342.08FU_UDB028691_reps                             unidentified      1  \n",
+       "\n",
+       "[163332 rows x 20 columns]"
+      ]
+     },
+     "execution_count": 89,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "full_results_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 87,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'k': 1.0,\n",
+       " 'p': 0.9110033551294296,\n",
+       " 'c': 0.4338953787377856,\n",
+       " 'o': 0.4282749246932628,\n",
+       " 'f': 0.004114319300565719,\n",
+       " 'g': 0.38500722454877184,\n",
+       " 's': 0.030410452330223103}"
+      ]
+     },
+     "execution_count": 87,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "###looking at unfiltered results\n",
+    "###look at the results unfiltered\n",
+    "full_results_df['count'] = 1\n",
+    "\n",
+    "get_accuracy_dict(full_results_df, query_tax_dict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### These are wired results that might be linked to\n",
+    "\n",
+    "* database issues as you can see\n",
+    "\n",
+    "sh_taxonomy_qiime_ver8_dynamic_02.02.2019.txt: k__Fungi;p__Ascomycota;c__Eurotiomycetes;o__Eurotiales;f__Aspergillaceae;g__Penicillium;s__Penicillium_chrysogenum"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 88,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>count</th>\n",
+       "      <th>k</th>\n",
+       "      <th>p</th>\n",
+       "      <th>c</th>\n",
+       "      <th>o</th>\n",
+       "      <th>f</th>\n",
+       "      <th>g</th>\n",
+       "      <th>s</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>tname</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>SH1530047.08FU_HE649392_reps</th>\n",
+       "      <td>50</td>\n",
+       "      <td>Fungi</td>\n",
+       "      <td>Ascomycota</td>\n",
+       "      <td>Eurotiomycetes</td>\n",
+       "      <td>Eurotiales</td>\n",
+       "      <td>Aspergillaceae</td>\n",
+       "      <td>Penicillium</td>\n",
+       "      <td>Penicillium_chrysogenum</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>SH2189908.08FU_AY213669_refs</th>\n",
+       "      <td>39</td>\n",
+       "      <td>Fungi</td>\n",
+       "      <td>Ascomycota</td>\n",
+       "      <td>Eurotiomycetes</td>\n",
+       "      <td>Eurotiales</td>\n",
+       "      <td>Aspergillaceae</td>\n",
+       "      <td>Penicillium</td>\n",
+       "      <td>Penicillium_chrysogenum</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                              count      k           p               c  \\\n",
+       "tname                                                                    \n",
+       "SH1530047.08FU_HE649392_reps     50  Fungi  Ascomycota  Eurotiomycetes   \n",
+       "SH2189908.08FU_AY213669_refs     39  Fungi  Ascomycota  Eurotiomycetes   \n",
+       "\n",
+       "                                       o               f            g  \\\n",
+       "tname                                                                   \n",
+       "SH1530047.08FU_HE649392_reps  Eurotiales  Aspergillaceae  Penicillium   \n",
+       "SH2189908.08FU_AY213669_refs  Eurotiales  Aspergillaceae  Penicillium   \n",
+       "\n",
+       "                                                    s  \n",
+       "tname                                                  \n",
+       "SH1530047.08FU_HE649392_reps  Penicillium_chrysogenum  \n",
+       "SH2189908.08FU_AY213669_refs  Penicillium_chrysogenum  "
+      ]
+     },
+     "execution_count": 88,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mapping_results[mapping_results['s'] == 'Penicillium_chrysogenum']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'k': 'Fungi',\n",
+       " 'p': 'Ascomycota',\n",
+       " 'c': 'Eurotiomycetes',\n",
+       " 'o': 'Eurotiales',\n",
+       " 'f': 'Aspergillaceae',\n",
+       " 'g': 'Penicillium',\n",
+       " 's': 'Penicillium_chrysogenum'}"
+      ]
+     },
+     "execution_count": 60,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "query_tax_dict = {}\n",
+    "taxrank = 'k__Fungi;p__Ascomycota;c__Eurotiomycetes;o__Eurotiales;f__Aspergillaceae;g__Penicillium;s__Penicillium_chrysogenum'\n",
+    "for rank_id in taxrank.split(';'):\n",
+    "    query_tax_dict[rank_id.split('__')[0]] = rank_id.split('__')[1]\n",
+    "query_tax_dict"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'k': 1.0,\n",
+       " 'p': 0.8811273411596021,\n",
+       " 'c': 0.18675508558114526,\n",
+       " 'o': 0.18594856169907698,\n",
+       " 'f': 0.18505242405233444,\n",
+       " 'g': 0.08275831167667354,\n",
+       " 's': 0.003987812528004301}"
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "get_accuracy_dict(mapping_results, query_tax_dict)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 62,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "###There must be more or equal number of mapping results compared to number of mapped reads\n",
+    "mapping_results['count'].sum() >= full_results_df.qseqid.unique().shape[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Testing on Candida albicans"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ":(check one reformat.sh samplereadstarget=20000 in=/media/MassStorage/tmp/TE/honours/analysis/Length_Filtered/20180108_FAH18647/barcode03/length_restricted_for_use.fasta out=/media/WorkingStorage/ben.working/students/tavish/analysis/qiime2/subsamplereads/candida_albicans.20000.fasta!!\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "#subsample tests species\n",
+    "fn_subsampling = {}\n",
+    "test_species = ['candida_albicans']\n",
+    "for x in test_species:\n",
+    "    fn_subsampling[x] = (ref_df[(ref_df['species'] == x.split('_')[1]) & (ref_df['genus'] == x.split('_')[0])]['path for use'].tolist()[0])\n",
+    "    fn_subsampling[x] = os.path.join(INPUT_BASEDIR, fn_subsampling[x])\n",
+    "\n",
+    "sub_reads_fn = {}\n",
+    "n_reads = 20000\n",
+    "for key, value in fn_subsampling.items():\n",
+    "    species = key\n",
+    "    in_fn = value\n",
+    "    out_fn = os.path.join(subsampling_dir, F'{species}.{n_reads}.fasta')\n",
+    "    subsamplereads(in_fn, out_fn, n_reads)\n",
+    "    sub_reads_fn[species] = out_fn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ":)Completed minimap2 -x map-ont -t 10 /media/WorkingStorage/ben.working/students/tavish/analysis/qiime2/db/sh_refs_qiime_ver8_dynamic_02.02.2019.fasta /media/WorkingStorage/ben.working/students/tavish/analysis/qiime2/subsamplereads/candida_albicans.20000.fasta -o /media/WorkingStorage/ben.working/students/tavish/analysis/qiime2/sh_refs_qiime_ver8_dynamic_02_02_2019/sh_refs_qiime_ver8_dynamic_02.02.2019.candida_albicans.minimap2.paf\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "###Map the reads\n",
+    "db_fn = qiime_db_fn\n",
+    "sub_db_mapping_fn = {}\n",
+    "for species, fasta_fn in sub_reads_fn.items():\n",
+    "    db_name = os.path.basename(db_fn).replace('.fasta', '')\n",
+    "    out_fn = os.path.join(mapping_dir, F\"{db_name}.{species}.minimap2.paf\")\n",
+    "    sub_db_mapping_fn[species] = out_fn\n",
+    "    minimapmapping(fasta_fn, db_fn, out_fn, threads)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/media/WorkingStorage/ben.working/students/tavish/analysis/qiime2/sh_refs_qiime_ver8_dynamic_02_02_2019/sh_refs_qiime_ver8_dynamic_02.02.2019.candida_albicans.minimap2.paf\n"
+     ]
+    }
+   ],
+   "source": [
+    "###Test out the summary results statistic for a single mapping result\n",
+    "species = test_species[0]\n",
+    "print(sub_db_mapping_fn[species])\n",
+    "mapping_results , full_results_df = pull_mapping_results_v2(sub_db_mapping_fn[species])\n",
+    "mapping_results = assign_taxranks_results(mapping_results, qiime_tax_fn)\n",
+    "taxfileid = getquery_taxfileid(reference_dataframe_fn, species)\n",
+    "query_tax_dict = get_taxid_dict(taxonomy_file_fn, taxfileid)\n",
+    "\n",
+    "sensitivity_dict = get_accuracy_dict(mapping_results, query_tax_dict)\n",
+    "\n",
+    "###Also look at the full results dataframe to explore results a bit more\n",
+    "#for tname in full_results_df.tname.unique():\n",
+    "    #tmp_tax_dict = get_taxid_dict(qiime_tax_fn, tname)\n",
+    "    #for key, value in tmp_tax_dict.items():\n",
+    "        #full_results_df.loc[tname, key] = value"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'k': 1.0,\n",
+       " 'p': 0.8180013515796587,\n",
+       " 'c': 0.5216252745396182,\n",
+       " 'o': 0.5216252745396182,\n",
+       " 'f': 0.07247845919918905,\n",
+       " 'g': 0.44749957763135667,\n",
+       " 's': 0.4208058793715155}"
+      ]
+     },
+     "execution_count": 66,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sensitivity_dict"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Might want to double check how your families are matched in your taxonomic input file for your known test species"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>count</th>\n",
+       "      <th>k</th>\n",
+       "      <th>p</th>\n",
+       "      <th>c</th>\n",
+       "      <th>o</th>\n",
+       "      <th>f</th>\n",
+       "      <th>g</th>\n",
+       "      <th>s</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>tname</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>SH1570378.08FU_MF767825_reps</th>\n",
+       "      <td>7823</td>\n",
+       "      <td>Fungi</td>\n",
+       "      <td>Ascomycota</td>\n",
+       "      <td>Saccharomycetes</td>\n",
+       "      <td>Saccharomycetales</td>\n",
+       "      <td>Saccharomycetales_fam_Incertae_sedis</td>\n",
+       "      <td>Candida</td>\n",
+       "      <td>Candida_albicans</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>SH1570374.08FU_EF567995_refs</th>\n",
+       "      <td>2102</td>\n",
+       "      <td>Fungi</td>\n",
+       "      <td>Ascomycota</td>\n",
+       "      <td>Saccharomycetes</td>\n",
+       "      <td>Saccharomycetales</td>\n",
+       "      <td>Saccharomycetales_fam_Incertae_sedis</td>\n",
+       "      <td>Candida</td>\n",
+       "      <td>Candida_albicans</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>SH1570379.08FU_KP675460_reps</th>\n",
+       "      <td>16</td>\n",
+       "      <td>Fungi</td>\n",
+       "      <td>Ascomycota</td>\n",
+       "      <td>Saccharomycetes</td>\n",
+       "      <td>Saccharomycetales</td>\n",
+       "      <td>Saccharomycetales_fam_Incertae_sedis</td>\n",
+       "      <td>Candida</td>\n",
+       "      <td>Candida_albicans</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>SH1570376.08FU_GQ280331_reps</th>\n",
+       "      <td>11</td>\n",
+       "      <td>Fungi</td>\n",
+       "      <td>Ascomycota</td>\n",
+       "      <td>Saccharomycetes</td>\n",
+       "      <td>Saccharomycetales</td>\n",
+       "      <td>Saccharomycetales_fam_Incertae_sedis</td>\n",
+       "      <td>Candida</td>\n",
+       "      <td>Candida_albicans</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>SH1570377.08FU_KP674963_reps</th>\n",
+       "      <td>11</td>\n",
+       "      <td>Fungi</td>\n",
+       "      <td>Ascomycota</td>\n",
+       "      <td>Saccharomycetes</td>\n",
+       "      <td>Saccharomycetales</td>\n",
+       "      <td>Saccharomycetales_fam_Incertae_sedis</td>\n",
+       "      <td>Candida</td>\n",
+       "      <td>Candida_albicans</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                              count      k           p                c  \\\n",
+       "tname                                                                     \n",
+       "SH1570378.08FU_MF767825_reps   7823  Fungi  Ascomycota  Saccharomycetes   \n",
+       "SH1570374.08FU_EF567995_refs   2102  Fungi  Ascomycota  Saccharomycetes   \n",
+       "SH1570379.08FU_KP675460_reps     16  Fungi  Ascomycota  Saccharomycetes   \n",
+       "SH1570376.08FU_GQ280331_reps     11  Fungi  Ascomycota  Saccharomycetes   \n",
+       "SH1570377.08FU_KP674963_reps     11  Fungi  Ascomycota  Saccharomycetes   \n",
+       "\n",
+       "                                              o  \\\n",
+       "tname                                             \n",
+       "SH1570378.08FU_MF767825_reps  Saccharomycetales   \n",
+       "SH1570374.08FU_EF567995_refs  Saccharomycetales   \n",
+       "SH1570379.08FU_KP675460_reps  Saccharomycetales   \n",
+       "SH1570376.08FU_GQ280331_reps  Saccharomycetales   \n",
+       "SH1570377.08FU_KP674963_reps  Saccharomycetales   \n",
+       "\n",
+       "                                                                 f        g  \\\n",
+       "tname                                                                         \n",
+       "SH1570378.08FU_MF767825_reps  Saccharomycetales_fam_Incertae_sedis  Candida   \n",
+       "SH1570374.08FU_EF567995_refs  Saccharomycetales_fam_Incertae_sedis  Candida   \n",
+       "SH1570379.08FU_KP675460_reps  Saccharomycetales_fam_Incertae_sedis  Candida   \n",
+       "SH1570376.08FU_GQ280331_reps  Saccharomycetales_fam_Incertae_sedis  Candida   \n",
+       "SH1570377.08FU_KP674963_reps  Saccharomycetales_fam_Incertae_sedis  Candida   \n",
+       "\n",
+       "                                             s  \n",
+       "tname                                           \n",
+       "SH1570378.08FU_MF767825_reps  Candida_albicans  \n",
+       "SH1570374.08FU_EF567995_refs  Candida_albicans  \n",
+       "SH1570379.08FU_KP675460_reps  Candida_albicans  \n",
+       "SH1570376.08FU_GQ280331_reps  Candida_albicans  \n",
+       "SH1570377.08FU_KP674963_reps  Candida_albicans  "
+      ]
+     },
+     "execution_count": 67,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mapping_results[mapping_results['s'] == 'Candida_albicans']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query_tax_dict['f'] = 'Saccharomycetales_fam_Incertae_sedis'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'k': 1.0,\n",
+       " 'p': 0.8180013515796587,\n",
+       " 'c': 0.5216252745396182,\n",
+       " 'o': 0.5216252745396182,\n",
+       " 'f': 0.44749957763135667,\n",
+       " 'g': 0.44749957763135667,\n",
+       " 's': 0.4208058793715155}"
+      ]
+     },
+     "execution_count": 69,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "get_accuracy_dict(mapping_results, query_tax_dict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### It appears that the filtering of results by mapping quality works well for the long ITS database but not for the quiime"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['qseqid', 'qlen', 'qstart', 'qstop', 'strand', 'tname', 'tlen',\n",
+       "       'tstart', 'tend', 'nmatch', 'alen', 'mquality', 'k', 'p', 'c', 'o', 'f',\n",
+       "       'g', 's'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 70,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "full_results_df.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(133263,)"
+      ]
+     },
+     "execution_count": 71,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "full_results_df.tname.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 72,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(166,)"
+      ]
+     },
+     "execution_count": 72,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "full_results_df.tname.unique().shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 73,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "full_results_df.index = full_results_df.tname"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 74,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "###Asign taxonomic rangs to the full_results_df\n",
+    "for tname in full_results_df.tname.unique():\n",
+    "    tmp_tax_dict = get_taxid_dict(qiime_tax_fn, tname)\n",
+    "    for key, value in tmp_tax_dict.items():\n",
+    "        full_results_df.loc[tname, key] = value"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 75,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(28996,)"
+      ]
+     },
+     "execution_count": 75,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "full_results_df[full_results_df['g'] == 'Candida']['qseqid'].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 76,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(18020,)"
+      ]
+     },
+     "execution_count": 76,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "full_results_df[full_results_df['g'] == 'Candida']['qseqid'].unique().shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 77,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'k': 1.0,\n",
+       " 'p': 0.8166107621770484,\n",
+       " 'c': 0.29843992706152495,\n",
+       " 'o': 0.29843992706152495,\n",
+       " 'f': 0.21758477596932382,\n",
+       " 'g': 0.21758477596932382,\n",
+       " 's': 0.17861672031996878}"
+      ]
+     },
+     "execution_count": 77,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "###look at the results unfiltered\n",
+    "full_results_df['count'] = 1\n",
+    "\n",
+    "get_accuracy_dict(full_results_df, query_tax_dict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Looking at the results unfiltered doesn't really work very well either. Might need to look into different filtering of the alignments or the qiime2 database might be just not really useful for the noise reads. Simulated reads with higher accuracy should get better here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 78,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "g\n",
+       "Candida                28996\n",
+       "Acidea                 16895\n",
+       "Plectosphaerella       12211\n",
+       "unidentified           10961\n",
+       "Nakaseomyces           10270\n",
+       "Oidiodendron            9451\n",
+       "Tomentella              8991\n",
+       "Knoxdaviesia            7543\n",
+       "Lignincola              6168\n",
+       "Cystoagaricus           5014\n",
+       "Lacrymaria              4981\n",
+       "Bannoa                  4605\n",
+       "Pseudorobillarda        2802\n",
+       "Deltopyxis               861\n",
+       "Pestalotiopsis           699\n",
+       "Leveillula               684\n",
+       "Wickerhamiella           411\n",
+       "Orpinomyces              372\n",
+       "Exophiala                144\n",
+       "Phyllactinia             136\n",
+       "Physcia                  130\n",
+       "Sporisorium              129\n",
+       "Pyrenodesmia             126\n",
+       "Physconia                118\n",
+       "Rhinocladiella           106\n",
+       "Pseudophaeomoniella      103\n",
+       "Sclerophora              101\n",
+       "Conioscypha               38\n",
+       "Chromocleista             37\n",
+       "Fusarium                  33\n",
+       "Rhodotorula               28\n",
+       "Xylaria                   18\n",
+       "Lodderomyces              16\n",
+       "Scheffersomyces           16\n",
+       "Spathaspora               10\n",
+       "Wickerhamomyces            9\n",
+       "Saccharomyces              6\n",
+       "Babjeviella                6\n",
+       "Obolarina                  5\n",
+       "Yamadazyma                 4\n",
+       "Nematodospora              4\n",
+       "Kluyveromyces              3\n",
+       "Tetrapisispora             2\n",
+       "Pichia                     2\n",
+       "Lachancea                  2\n",
+       "Strobilomyces              2\n",
+       "Schwanniomyces             1\n",
+       "Priceomyces                1\n",
+       "Barnettozyma               1\n",
+       "Beauveria                  1\n",
+       "Peziza                     1\n",
+       "Debaryomyces               1\n",
+       "Cyberlindnera              1\n",
+       "Saccharomycopsis           1\n",
+       "Millerozyma                1\n",
+       "Galiella                   1\n",
+       "Histoplasma                1\n",
+       "Issatchenkia               1\n",
+       "Microstoma                 1\n",
+       "Lactarius                  1\n",
+       "Name: k, dtype: int64"
+      ]
+     },
+     "execution_count": 78,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "full_results_df.groupby('g').count()['k'].sort_values(ascending=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 79,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 79,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "###There must be more or equal number of mapping results compared to number of mapped reads\n",
+    "mapping_results['count'].sum() >= full_results_df.qseqid.unique().shape[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Test run on the quiime2 Database 99\n",
+    "\n",
+    "##### Prep on the command line\n",
+    "\n",
+    "cp sh_refs_qiime_ver8_99_02.02.2019.fasta /media/WorkingStorage/ben.working/students/tavish/analysis/qiime2/db/. \n",
+    "cp sh_taxonomy_qiime_ver8_99_02.02.2019.txt /media/WorkingStorage/ben.working/students/tavish/analysis/qiime2/db/."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 91,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "qiime_db_fn = os.path.abspath('../../analysis/qiime2/db/sh_refs_qiime_ver8_99_02.02.2019.fasta')\n",
+    "qiime_tax_fn = os.path.abspath('../../analysis/qiime2/db/sh_taxonomy_qiime_ver8_99_02.02.2019.txt')\n",
+    "threads = 10\n",
+    "QIIME_DIR = os.path.abspath('../../analysis/qiime2/')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 92,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "##mapping folder\n",
+    "mapping_dir = os.path.join(QIIME_DIR, os.path.basename(qiime_db_fn).replace('.fasta', '').replace('.','_'))\n",
+    "if not os.path.exists(mapping_dir):\n",
+    "    os.mkdir(mapping_dir)\n",
+    "subsampling_dir = os.path.join(QIIME_DIR, 'subsamplereads')\n",
+    "if not os.path.exists(subsampling_dir):\n",
+    "    os.mkdir(subsampling_dir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 94,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ":(check one reformat.sh samplereadstarget=20000 in=/media/MassStorage/tmp/TE/honours/analysis/Length_Filtered/20171103_FAH15473/barcode10/length_restricted_for_use.fasta out=/media/WorkingStorage/ben.working/students/tavish/analysis/qiime2/subsamplereads/penicillium_chrysogenum.20000.fasta!!\n",
+      "\n",
+      ":)Completed minimap2 -x map-ont -t 10 /media/WorkingStorage/ben.working/students/tavish/analysis/qiime2/db/sh_refs_qiime_ver8_99_02.02.2019.fasta /media/WorkingStorage/ben.working/students/tavish/analysis/qiime2/subsamplereads/penicillium_chrysogenum.20000.fasta -o /media/WorkingStorage/ben.working/students/tavish/analysis/qiime2/sh_refs_qiime_ver8_99_02_02_2019/sh_refs_qiime_ver8_99_02.02.2019.penicillium_chrysogenum.minimap2.paf\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "#subsample tests species\n",
+    "fn_subsampling = {}\n",
+    "test_species = ['penicillium_chrysogenum']\n",
+    "for x in test_species:\n",
+    "    fn_subsampling[x] = (ref_df[(ref_df['species'] == x.split('_')[1]) & (ref_df['genus'] == x.split('_')[0])]['path for use'].tolist()[0])\n",
+    "    fn_subsampling[x] = os.path.join(INPUT_BASEDIR, fn_subsampling[x])\n",
+    "\n",
+    "sub_reads_fn = {}\n",
+    "n_reads = 20000\n",
+    "for key, value in fn_subsampling.items():\n",
+    "    species = key\n",
+    "    in_fn = value\n",
+    "    out_fn = os.path.join(subsampling_dir, F'{species}.{n_reads}.fasta')\n",
+    "    subsamplereads(in_fn, out_fn, n_reads)\n",
+    "    sub_reads_fn[species] = out_fn\n",
+    "\n",
+    "###Map the reads\n",
+    "db_fn = qiime_db_fn\n",
+    "sub_db_mapping_fn = {}\n",
+    "for species, fasta_fn in sub_reads_fn.items():\n",
+    "    db_name = os.path.basename(db_fn).replace('.fasta', '')\n",
+    "    out_fn = os.path.join(mapping_dir, F\"{db_name}.{species}.minimap2.paf\")\n",
+    "    sub_db_mapping_fn[species] = out_fn\n",
+    "    minimapmapping(fasta_fn, db_fn, out_fn, threads)\n",
+    "\n",
+    "###Test out the summary results statistic for a single mapping result\n",
+    "species = 'penicillium_chrysogenum'\n",
+    "mapping_results , full_results_df = pull_mapping_results_v2(sub_db_mapping_fn[species])\n",
+    "mapping_results = assign_taxranks_results(mapping_results, qiime_tax_fn)\n",
+    "taxfileid = getquery_taxfileid(reference_dataframe_fn, species)\n",
+    "query_tax_dict = get_taxid_dict(taxonomy_file_fn, taxfileid)\n",
+    "###fix family level for 'penicillium_chrysogenum'\n",
+    "query_tax_dict['f'] = 'Trichomonascaceae'\n",
+    "sensitivity_dict = get_accuracy_dict(mapping_results, query_tax_dict)\n",
+    "\n",
+    "\n",
+    "full_results_df.index = full_results_df.tname\n",
+    "###Also look at the full results dataframe to explore results a bit more\n",
+    "for tname in full_results_df.tname.unique():\n",
+    "\n",
+    "    tmp_tax_dict = get_taxid_dict(qiime_tax_fn, tname)\n",
+    "    for key, value in tmp_tax_dict.items():\n",
+    "        full_results_df.loc[tname, key] = value"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 95,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'k': 1.0,\n",
+       " 'p': 0.7808393002809753,\n",
+       " 'c': 0.26216804133055377,\n",
+       " 'o': 0.2609444394090456,\n",
+       " 'f': 0.005030363455089277,\n",
+       " 'g': 0.10237469409951962,\n",
+       " 's': 4.5318589685488985e-05}"
+      ]
+     },
+     "execution_count": 95,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sensitivity_dict"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 96,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'k': 1.0,\n",
+       " 'p': 0.837235656449343,\n",
+       " 'c': 0.3831831502501021,\n",
+       " 'o': 0.37726112360098213,\n",
+       " 'f': 0.004941114827609317,\n",
+       " 'g': 0.29803878561897973,\n",
+       " 's': 7.311144011259162e-05}"
+      ]
+     },
+     "execution_count": 96,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "###looking at unfiltered results\n",
+    "###look at the results unfiltered\n",
+    "full_results_df['count'] = 1\n",
+    "\n",
+    "get_accuracy_dict(full_results_df, query_tax_dict)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 99,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "###fix the query_tax_dict with the data found in the qiime database\n",
+    "query_tax_dict = {}\n",
+    "taxrank = 'k__Fungi;p__Ascomycota;c__Eurotiomycetes;o__Eurotiales;f__Aspergillaceae;g__Penicillium;s__Penicillium_chrysogenum'\n",
+    "for rank_id in taxrank.split(';'):\n",
+    "    query_tax_dict[rank_id.split('__')[0]] = rank_id.split('__')[1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 100,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'k': 1.0,\n",
+       " 'p': 0.7808393002809753,\n",
+       " 'c': 0.26216804133055377,\n",
+       " 'o': 0.2609444394090456,\n",
+       " 'f': 0.2585425541557147,\n",
+       " 'g': 0.10237469409951962,\n",
+       " 's': 4.5318589685488985e-05}"
+      ]
+     },
+     "execution_count": 100,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "get_accuracy_dict(mapping_results, query_tax_dict)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This is a further worked on notebook Synthetic mock community analysis.ipynb having removed the white spaces in the name.

I fixed some of the scoring algorithms in the following functions:

* mapping_results
* pull_mapping_results

These scoring functions seem to work well with the long ITS sequences. I also developed some more functions that summarize the results at all taxonomics ranks. This works for all. 

I test run two species (Candida albicans and Penicillium chrysogenum) against some Qiime ITS databases. At times Tavish will have to check the taxonomics assignments at the family level for the queries. There seems to be a bit of inconsistency in Qiime and the homemade database. I think Qiime isn't great here.

One idea would be to pull in the Qiime taxonomic assignemnt of each query when possible and use this for analysis.

Overall assigning against Qiime doesn't work great. Will have to explore maybe a bit more the filtering of results including the nmatch of minimap2. Currently a bit unsure if this is fully correct. Maybe another algorithm would work better here. Good to mention in the discussion of the thesis.

Nothing to worry about too much. Kind of expected that the Qiime or other shorter sequence databases don't work very well with the noise reads.